### PR TITLE
Add compatibility for Windows and MSVC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,12 +83,18 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup MSVC Developer Command Prompt
         uses: ilammy/msvc-dev-cmd@v1
-      - name: Compile with MSVC
+      - name: Compile Single-Threaded TLSF with MSVC
         run: |
           cl.exe /Iinclude /O2 /W3 /DTLSF_ENABLE_ASSERT /DTLSF_ENABLE_CHECK src\tlsf.c tests\test.c /Fe:test_tlsf.exe
-      - name: Run Tests
+      - name: Run Single-Threaded Tests
         run: |
           .\test_tlsf.exe
+      - name: Compile Multi-Threaded TLSF with MSVC (C11)
+        run: |
+          cl.exe /Iinclude /O2 /W3 /std:c11 /DTLSF_ENABLE_ASSERT /DTLSF_ENABLE_CHECK /DTLSF_C11_THREADS src\tlsf.c src\tlsf_thread.c tests\test_thread.c /Fe:test_thread.exe
+      - name: Run Multi-Threaded Tests
+        run: |
+          .\test_thread.exe
   
   wcet:
     needs: [coding-style, build-and-test]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,22 @@ jobs:
         env:
           CC: ${{ matrix.cc }}
           CFLAGS: ${{ matrix.cflags }}
-
+  
+  build-windows-msvc:
+    needs: coding-style
+    runs-on: windows-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - name: Setup MSVC Developer Command Prompt
+        uses: ilammy/msvc-dev-cmd@v1
+      - name: Compile with MSVC
+        run: |
+          cl.exe /Iinclude /O2 /W3 /DTLSF_ENABLE_ASSERT /DTLSF_ENABLE_CHECK src\tlsf.c tests\test.c /Fe:test_tlsf.exe
+      - name: Run Tests
+        run: |
+          .\test_tlsf.exe
+  
   wcet:
     needs: [coding-style, build-and-test]
     runs-on: ${{ matrix.runner }}

--- a/include/tlsf.h
+++ b/include/tlsf.h
@@ -34,7 +34,7 @@ extern "C" {
 #endif
 #elif defined(__GNUC__) || defined(__MINGW32__) || defined(__MINGW64__) ||  defined(__clang__)
 #define _TLSF_SIZE_WIDTH __SIZE_WIDTH__
-#elif
+#else
 #if INTPTR_MAX == INT64_MAX
 #define _TLSF_SIZE_WIDTH 64
 #elif INTPTR_MAX == INT32_MAX

--- a/include/tlsf.h
+++ b/include/tlsf.h
@@ -34,6 +34,14 @@ extern "C" {
 #endif
 #elif defined(__GNUC__) || defined(__MINGW32__) || defined(__MINGW64__) ||  defined(__clang__)
 #define _TLSF_SIZE_WIDTH __SIZE_WIDTH__
+#elif
+#if INTPTR_MAX == INT64_MAX
+#define _TLSF_SIZE_WIDTH 64
+#elif INTPTR_MAX == INT32_MAX
+#define _TLSF_SIZE_WIDTH 32
+#else
+#error No support for non 32 or 64 bit systems
+#endif
 #endif
 #endif
 

--- a/include/tlsf.h
+++ b/include/tlsf.h
@@ -25,6 +25,18 @@ extern "C" {
  */
 #define _TLSF_SL_COUNT 32
 
+#ifndef _TLSF_SIZE_WIDTH
+#if defined(_MSC_VER)
+#if defined(_WIN64)
+#define _TLSF_SIZE_WIDTH 64
+#else
+#define _TLSF_SIZE_WIDTH 32
+#endif
+#elif defined(__GNUC__) || defined(__MINGW32__) || defined(__MINGW64__) ||  defined(__clang__)
+#define _TLSF_SIZE_WIDTH __SIZE_WIDTH__
+#endif
+#endif
+
 /*
  * Configurable maximum pool size: define TLSF_MAX_POOL_BITS to clamp
  * the first-level index, reducing the tlsf_t control structure size.
@@ -34,7 +46,7 @@ extern "C" {
 #ifdef TLSF_MAX_POOL_BITS
 #define _TLSF_FL_MAX TLSF_MAX_POOL_BITS
 #else
-#if __SIZE_WIDTH__ == 64
+#if _TLSF_SIZE_WIDTH == 64
 #define _TLSF_FL_MAX 39
 #else
 #define _TLSF_FL_MAX 31
@@ -42,7 +54,7 @@ extern "C" {
 #endif
 
 /* FL_SHIFT = log2(SL_COUNT) + log2(ALIGN_SIZE) */
-#if __SIZE_WIDTH__ == 64
+#if _TLSF_SIZE_WIDTH == 64
 #define _TLSF_FL_SHIFT 8
 #else
 #define _TLSF_FL_SHIFT 7
@@ -50,6 +62,14 @@ extern "C" {
 #define _TLSF_FL_COUNT (_TLSF_FL_MAX - _TLSF_FL_SHIFT + 1)
 #define TLSF_MAX_SIZE (((size_t) 1 << (_TLSF_FL_MAX - 1)) - sizeof(size_t))
 #define TLSF_INIT ((tlsf_t) {.size = 0})
+
+/* TLSF_INIT_STATIC is need to be used instead of TLSF_INIT for initializing
+static objects for cross platform compatibility */
+#if defined(_MSC_VER)
+#define TLSF_INIT_STATIC { .size = 0 }
+#else
+#define TLSF_INIT_STATIC ((tlsf_t) {.size = 0})
+#endif
 
 /*
  * Block header structure.

--- a/include/tlsf_thread.h
+++ b/include/tlsf_thread.h
@@ -98,7 +98,14 @@ extern "C" {
 #include <windows.h>
 #endif
 
-#if defined(TLSF_THREAD_WIN)
+#if defined (USE_C11_THREADS)
+#define TLSF_LOCK_T mtx_t
+#define TLSF_LOCK_INIT(l) mtx_init((l), mtx_plain)
+#define TLSF_LOCK_DESTROY(l) mtx_destroy((l))
+#define TLSF_LOCK_ACQUIRE(l) mtx_lock((l))
+#define TLSF_LOCK_RELEASE(l) mtx_unlock((l))
+#define TLSF_LOCK_TRY(l) (mtx_trylock((l)) == thrd_success)
+#elif defined(TLSF_THREAD_WIN)
 #define TLSF_LOCK_T CRITICAL_SECTION
 #define TLSF_LOCK_INIT(l) (InitializeCriticalSection((l)), 0)
 #define TLSF_LOCK_DESTROY(l) DeleteCriticalSection((l))
@@ -112,13 +119,6 @@ extern "C" {
 #define TLSF_LOCK_ACQUIRE(l) pthread_mutex_lock((l))
 #define TLSF_LOCK_RELEASE(l) pthread_mutex_unlock((l))
 #define TLSF_LOCK_TRY(l) (pthread_mutex_trylock((l)) == 0)
-#elif defined (USE_C11_THREADS)
-#define TLSF_LOCK_T mtx_t
-#define TLSF_LOCK_INIT(l) mtx_init((l), mtx_plain)
-#define TLSF_LOCK_DESTROY(l) mtx_destroy((l))
-#define TLSF_LOCK_ACQUIRE(l) mtx_lock((l))
-#define TLSF_LOCK_RELEASE(l) mtx_unlock((l))
-#define TLSF_LOCK_TRY(l) (mtx_trylock((l)) == thrd_success)
 #endif
 
 /* Fold upper bits into lower 32 to retain entropy on 64-bit systems. */

--- a/include/tlsf_thread.h
+++ b/include/tlsf_thread.h
@@ -62,27 +62,97 @@ extern "C" {
 
 #ifndef TLSF_LOCK_T
 
-#include <pthread.h>
+#if defined(_MSC_VER)
+#if (_MSC_VER < 1935)
+#error Incompatible Visual C++ version. Requires VS 2022 17.5+ for C11 threads support.
+#elif !defined(__STDC_VERSION__) || (__STDC_VERSION__ < 201112L)
+#error MSVC /std:c11 compiler switch is missing! Please enable C11 standard or higher in project properties.
+#else
+#define C11_THREADS_SUPPORT 1
+#endif
+#else
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L) && !defined(__STDC_NO_THREADS__)
+#define C11_THREADS_SUPPORT 1
+#endif
+#endif
 
+#if defined(_WIN32) || defined(WIN32) || defined(__WIN32__) || defined(_WIN64)
+#define TLSF_THREAD_WIN
+#elif defined (__unix__) || defined(__APPLE__) || defined(__posix) || defined(__FreeBSD__) || defined(__linux__) || defined(__linux)
+#define TLSF_THREAD_POSIX
+#endif
+
+/* It is possible to switch to C11 threads in non windows environment too. For this define TLSF_C11_THREADS macro
+before include this header */
+#if (defined(TLSF_THREAD_WIN) && defined(C11_THREADS_SUPPORT)) || (defined(TLSF_C11_THREADS) && defined(C11_THREADS_SUPPORT))
+#define USE_C11_THREADS 1
+#endif
+
+#if defined(USE_C11_THREADS)
+#include <threads.h>
+#elif
+#include <pthread.h>
+#endif
+
+#if defined(USE_C11_THREADS)
+#define TLSF_LOCK_T mtx_t
+#define TLSF_LOCK_INIT(l) mtx_init((l), mtx_plain)
+#define TLSF_LOCK_DESTROY(l) mtx_destroy((l))
+#define TLSF_LOCK_ACQUIRE(l) mtx_lock((l))
+#define TLSF_LOCK_RELEASE(l) mtx_unlock((l))
+#define TLSF_LOCK_TRY(l) (mtx_trylock((l)) == thrd_success)
+#else
 #define TLSF_LOCK_T pthread_mutex_t
 #define TLSF_LOCK_INIT(l) pthread_mutex_init((l), NULL)
 #define TLSF_LOCK_DESTROY(l) pthread_mutex_destroy((l))
 #define TLSF_LOCK_ACQUIRE(l) pthread_mutex_lock((l))
 #define TLSF_LOCK_RELEASE(l) pthread_mutex_unlock((l))
 #define TLSF_LOCK_TRY(l) (pthread_mutex_trylock((l)) == 0)
-
-#ifndef TLSF_THREAD_HINT
-/* Fold upper bits into lower 32 to retain entropy on 64-bit systems. */
-#define TLSF_THREAD_HINT()                    \
-    ((unsigned) ((uintptr_t) pthread_self() ^ \
-                 ((uintptr_t) pthread_self() >> 16)))
 #endif
 
-#endif /* TLSF_LOCK_T */
-
-/* Fallback thread hint for custom locks without a custom hint. */
+/* Fold upper bits into lower 32 to retain entropy on 64-bit systems. */
 #ifndef TLSF_THREAD_HINT
+#if defined(USE_C11_THREADS)
+#if defined(TLSF_THREAD_WIN)
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#define TLSF_THREAD_HINT() ((unsigned) GetCurrentThreadId())
+#elif defined(TLSF_THREAD_POSIX)
+#include <pthread.h>
+#define TLSF_THREAD_HINT()                 \
+                ((unsigned) ((uintptr_t) pthread_self() ^ \
+                             ((uintptr_t) pthread_self() >> 16)))
+#else
+#define TLSF_THREAD_HINT()                 \
+                ((unsigned) ((uintptr_t) thrd_current() ^ \
+                             ((uintptr_t) thrd_current() >> 16)))
+#endif
+#elif defined(C11_THREADS_SUPPORT) || defined(TLSF_C11_THREADS)
 #define TLSF_THREAD_HINT() 0U
+#else
+#if defined(TLSF_THREAD_POSIX)
+#define TLSF_THREAD_HINT()                    \
+                ((unsigned) ((uintptr_t) pthread_self() ^ \
+                             ((uintptr_t) pthread_self() >> 16)))
+#else
+#define TLSF_THREAD_HINT() 0U
+#endif
+#endif
+#endif
+
+#endif
+
+#if defined(_MSC_VER)
+#define TLSF_MSVC_ALIGN(x) __declspec(align(x))
+#define TLSF_GCC_ALIGN(x) 
+#elif defined(__GNUC__) || defined(__clang__)
+#define TLSF_MSVC_ALIGN(x)
+#define TLSF_GCC_ALIGN(x) __attribute__((aligned(x)))
+#else
+#define TLSF_MSVC_ALIGN(x)
+#define TLSF_GCC_ALIGN(x)
 #endif
 
 /*
@@ -115,12 +185,12 @@ _Static_assert(TLSF_ARENA_COUNT >= 1, "TLSF_ARENA_COUNT must be >= 1");
 _Static_assert((TLSF_CACHELINE_SIZE & (TLSF_CACHELINE_SIZE - 1)) == 0,
                "TLSF_CACHELINE_SIZE must be a power of two");
 
-typedef struct {
+TLSF_MSVC_ALIGN(TLSF_CACHELINE_SIZE) typedef struct {
     tlsf_t pool;
     TLSF_LOCK_T lock;
     void *base;      /* Arena memory base (for pointer ownership) */
     size_t capacity; /* Arena memory size in bytes */
-} __attribute__((aligned(TLSF_CACHELINE_SIZE))) tlsf_arena_t;
+} TLSF_GCC_ALIGN(TLSF_CACHELINE_SIZE) tlsf_arena_t;
 
 typedef struct {
     tlsf_arena_t arenas[TLSF_ARENA_COUNT];

--- a/include/tlsf_thread.h
+++ b/include/tlsf_thread.h
@@ -61,8 +61,9 @@ extern "C" {
  */
 
 #ifndef TLSF_LOCK_T
-
-#if defined(_MSC_VER)
+ /* It is possible to switch to C11 threads. For this define TLSF_C11_THREADS macro
+ in this header here */
+#if defined(_MSC_VER) && defined (TLSF_C11_THREADS)
 #if (_MSC_VER < 1935)
 #error Incompatible Visual C++ version. Requires VS 2022 17.5+ for C11 threads support.
 #elif !defined(__STDC_VERSION__) || (__STDC_VERSION__ < 201112L)
@@ -82,32 +83,42 @@ extern "C" {
 #define TLSF_THREAD_POSIX
 #endif
 
-/* It is possible to switch to C11 threads in non windows environment too. For this define TLSF_C11_THREADS macro
-before include this header */
 #if (defined(TLSF_THREAD_WIN) && defined(C11_THREADS_SUPPORT)) || (defined(TLSF_C11_THREADS) && defined(C11_THREADS_SUPPORT))
 #define USE_C11_THREADS 1
 #endif
 
 #if defined(USE_C11_THREADS)
 #include <threads.h>
-#elif
+#elif defined (TLSF_THREAD_POSIX)
 #include <pthread.h>
+#elif defined (TLSF_THREAD_WIN)
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
 #endif
 
-#if defined(USE_C11_THREADS)
-#define TLSF_LOCK_T mtx_t
-#define TLSF_LOCK_INIT(l) mtx_init((l), mtx_plain)
-#define TLSF_LOCK_DESTROY(l) mtx_destroy((l))
-#define TLSF_LOCK_ACQUIRE(l) mtx_lock((l))
-#define TLSF_LOCK_RELEASE(l) mtx_unlock((l))
-#define TLSF_LOCK_TRY(l) (mtx_trylock((l)) == thrd_success)
-#else
+#if defined(TLSF_THREAD_WIN)
+#define TLSF_LOCK_T CRITICAL_SECTION
+#define TLSF_LOCK_INIT(l) (InitializeCriticalSection((l)), 0)
+#define TLSF_LOCK_DESTROY(l) DeleteCriticalSection((l))
+#define TLSF_LOCK_ACQUIRE(l) EnterCriticalSection((l))
+#define TLSF_LOCK_RELEASE(l) LeaveCriticalSection((l))
+#define TLSF_LOCK_TRY(l) (TryEnterCriticalSection((l)) != 0)
+#elif defined (TLSF_THREAD_POSIX)
 #define TLSF_LOCK_T pthread_mutex_t
 #define TLSF_LOCK_INIT(l) pthread_mutex_init((l), NULL)
 #define TLSF_LOCK_DESTROY(l) pthread_mutex_destroy((l))
 #define TLSF_LOCK_ACQUIRE(l) pthread_mutex_lock((l))
 #define TLSF_LOCK_RELEASE(l) pthread_mutex_unlock((l))
 #define TLSF_LOCK_TRY(l) (pthread_mutex_trylock((l)) == 0)
+#elif defined (USE_C11_THREADS)
+#define TLSF_LOCK_T mtx_t
+#define TLSF_LOCK_INIT(l) mtx_init((l), mtx_plain)
+#define TLSF_LOCK_DESTROY(l) mtx_destroy((l))
+#define TLSF_LOCK_ACQUIRE(l) mtx_lock((l))
+#define TLSF_LOCK_RELEASE(l) mtx_unlock((l))
+#define TLSF_LOCK_TRY(l) (mtx_trylock((l)) == thrd_success)
 #endif
 
 /* Fold upper bits into lower 32 to retain entropy on 64-bit systems. */
@@ -136,6 +147,8 @@ before include this header */
 #define TLSF_THREAD_HINT()                    \
                 ((unsigned) ((uintptr_t) pthread_self() ^ \
                              ((uintptr_t) pthread_self() >> 16)))
+#elif defined(TLSF_THREAD_WIN)
+#define TLSF_THREAD_HINT() ((unsigned) GetCurrentThreadId())
 #else
 #define TLSF_THREAD_HINT() 0U
 #endif

--- a/include/tlsf_thread.h
+++ b/include/tlsf_thread.h
@@ -98,7 +98,7 @@ extern "C" {
 #include <windows.h>
 #endif
 
-#if defined (USE_C11_THREADS)
+#if defined(USE_C11_THREADS)
 #define TLSF_LOCK_T mtx_t
 #define TLSF_LOCK_INIT(l) mtx_init((l), mtx_plain)
 #define TLSF_LOCK_DESTROY(l) mtx_destroy((l))
@@ -112,7 +112,7 @@ extern "C" {
 #define TLSF_LOCK_ACQUIRE(l) EnterCriticalSection((l))
 #define TLSF_LOCK_RELEASE(l) LeaveCriticalSection((l))
 #define TLSF_LOCK_TRY(l) (TryEnterCriticalSection((l)) != 0)
-#elif defined (TLSF_THREAD_POSIX)
+#elif defined(TLSF_THREAD_POSIX)
 #define TLSF_LOCK_T pthread_mutex_t
 #define TLSF_LOCK_INIT(l) pthread_mutex_init((l), NULL)
 #define TLSF_LOCK_DESTROY(l) pthread_mutex_destroy((l))

--- a/include/tlsf_thread.h
+++ b/include/tlsf_thread.h
@@ -151,8 +151,12 @@ extern "C" {
 #endif
 #endif
 
-#endif
+#endif /* TLSF_LOCK_T */
 
+/* Fallback thread hint for custom locks without a custom hint. */
+#ifndef TLSF_THREAD_HINT
+#define TLSF_THREAD_HINT() 0U
+#endif
 
 #if defined(_MSC_VER)
 #define TLSF_MSVC_ALIGN(x) __declspec(align(x))

--- a/include/tlsf_thread.h
+++ b/include/tlsf_thread.h
@@ -140,10 +140,7 @@ extern "C" {
                 ((unsigned) ((uintptr_t) thrd_current() ^ \
                              ((uintptr_t) thrd_current() >> 16)))
 #endif
-#elif defined(C11_THREADS_SUPPORT) || defined(TLSF_C11_THREADS)
-#define TLSF_THREAD_HINT() 0U
-#else
-#if defined(TLSF_THREAD_POSIX)
+#elif defined(TLSF_THREAD_POSIX)
 #define TLSF_THREAD_HINT()                    \
                 ((unsigned) ((uintptr_t) pthread_self() ^ \
                              ((uintptr_t) pthread_self() >> 16)))
@@ -153,9 +150,9 @@ extern "C" {
 #define TLSF_THREAD_HINT() 0U
 #endif
 #endif
-#endif
 
 #endif
+
 
 #if defined(_MSC_VER)
 #define TLSF_MSVC_ALIGN(x) __declspec(align(x))

--- a/src/tlsf.c
+++ b/src/tlsf.c
@@ -191,8 +191,8 @@ INLINE uint32_t log2floor(size_t x)
 #if defined(__GNUC__) || defined(__MINGW32__) || defined(__MINGW64__) || defined(__clang__)
 #if _TLSF_SIZE_WIDTH == 64
     return (uint32_t) (63 - (uint32_t) __builtin_clzll((unsigned long long) x));
-#elif defined(_MSC_VER)
-    return (uint32_t) (63 - (uint32_t) msc_clzll((unsigned long long) x));
+#else
+    return (uint32_t) (31 - (uint32_t) __builtin_clzl((unsigned long) x));
 #endif
 #elif defined(_MSC_VER)
     unsigned long index;

--- a/src/tlsf.c
+++ b/src/tlsf.c
@@ -150,7 +150,7 @@ _Static_assert(FL_MAX < _TLSF_SIZE_WIDTH,
  * Note: __attribute__((weak)) requires GCC or Clang.  On compilers
  * without weak symbol support, users must always define tlsf_resize.
  */
-#if defined defined(__GNUC__) || defined(__MINGW32__) || defined(__MINGW64__) ||  defined(__clang__)
+#if defined (__GNUC__) || defined(__MINGW32__) || defined(__MINGW64__) ||  defined(__clang__)
 __attribute__((weak)) void *tlsf_resize(tlsf_t *t, size_t size)
 {
     (void) t;

--- a/src/tlsf.c
+++ b/src/tlsf.c
@@ -113,7 +113,7 @@
 #define INLINE static inline __attribute__((always_inline))
 #elif defined(_MSC_VER) 
 #define INLINE static __forceinline
-#elif
+#else
 #define INLINE static inline
 #endif
 #endif

--- a/src/tlsf.c
+++ b/src/tlsf.c
@@ -7,15 +7,23 @@
 #include <stdbool.h>
 #include <string.h>
 
+#if defined(_MSC_VER) && !defined(__clang__)
+#include <intrin.h>
+#endif
+
 #include "tlsf.h"
 
 #ifndef UNLIKELY
+#if defined(__GNUC__) || defined(__MINGW32__) || defined(__MINGW64__) || defined(__clang__)
 #define UNLIKELY(x) __builtin_expect(!!(x), false)
+#else
+#define UNLIKELY(x) (!!(x))
+#endif
 #endif
 
 /* All allocation sizes and addresses are aligned. */
 #define ALIGN_SIZE ((size_t) 1 << ALIGN_SHIFT)
-#if __SIZE_WIDTH__ == 64
+#if _TLSF_SIZE_WIDTH == 64
 #define ALIGN_SHIFT 3
 #else
 #define ALIGN_SHIFT 2
@@ -101,7 +109,13 @@
 #define BLOCK_PAYLOAD_OVERHEAD (sizeof(struct tlsf_block *) * 3)
 
 #ifndef INLINE
+#if defined(__GNUC__) || defined(__MINGW32__) || defined(__MINGW64__) || defined(__clang__)
 #define INLINE static inline __attribute__((always_inline))
+#elif defined(_MSC_VER) 
+#define INLINE static __forceinline
+#elif
+#define INLINE static inline
+#endif
 #endif
 
 typedef struct tlsf_block tlsf_block_t;
@@ -124,7 +138,7 @@ _Static_assert(TLSF_SPLIT_THRESHOLD >= BLOCK_SIZE_MIN,
                "split threshold must be at least minimum block size");
 _Static_assert(_TLSF_FL_COUNT >= 1,
                "TLSF_MAX_POOL_BITS too small for this architecture");
-_Static_assert(FL_MAX < __SIZE_WIDTH__,
+_Static_assert(FL_MAX < _TLSF_SIZE_WIDTH,
                "TLSF_MAX_POOL_BITS must be less than pointer width");
 
 /*
@@ -136,26 +150,58 @@ _Static_assert(FL_MAX < __SIZE_WIDTH__,
  * Note: __attribute__((weak)) requires GCC or Clang.  On compilers
  * without weak symbol support, users must always define tlsf_resize.
  */
+#if defined defined(__GNUC__) || defined(__MINGW32__) || defined(__MINGW64__) ||  defined(__clang__)
 __attribute__((weak)) void *tlsf_resize(tlsf_t *t, size_t size)
 {
     (void) t;
     (void) size;
     return NULL;
 }
+#elif defined(_MSC_VER)
+void* tlsf_resize_default(tlsf_t* t, size_t size)
+{
+    (void)t;
+    (void)size;
+    return NULL;
+}
+#if defined(_M_IX86)
+#pragma comment(linker, "/alternatename:_tlsf_resize=_tlsf_resize_default")
+#else
+#pragma comment(linker, "/alternatename:tlsf_resize=tlsf_resize_default")
+#endif
+#endif 
 
 INLINE uint32_t bitmap_ffs(uint32_t x)
 {
     ASSERT(x, "no set bit found");
+#if defined(__GNUC__) || defined(__MINGW32__) || defined(__MINGW64__) || defined(__clang__)
     return (uint32_t) __builtin_ctz(x);
+#elif defined(_MSC_VER)
+    unsigned long index;
+    if (_BitScanForward(&index, x)) {
+        return (int)(index);
+    }
+    return 0;
+#endif
 }
 
 INLINE uint32_t log2floor(size_t x)
 {
     ASSERT(x > 0, "log2 of zero");
-#if __SIZE_WIDTH__ == 64
+#if defined(__GNUC__) || defined(__MINGW32__) || defined(__MINGW64__) || defined(__clang__)
+#if _TLSF_SIZE_WIDTH == 64
     return (uint32_t) (63 - (uint32_t) __builtin_clzll((unsigned long long) x));
+#elif defined(_MSC_VER)
+    return (uint32_t) (63 - (uint32_t) msc_clzll((unsigned long long) x));
+#endif
+#elif defined(_MSC_VER)
+    unsigned long index;
+#if _TLSF_SIZE_WIDTH == 64
+    _BitScanReverse64(&index, (unsigned __int64)x);
 #else
-    return (uint32_t) (31 - (uint32_t) __builtin_clzl((unsigned long) x));
+    _BitScanReverse(&index, (unsigned long)x);
+#endif
+    return (uint32_t)index;
 #endif
 }
 
@@ -322,7 +368,7 @@ INLINE size_t round_block_size(size_t size)
      * because shifting zero by any valid amount yields zero.
      */
     uint32_t shift =
-        (lg - (uint32_t) SL_SHIFT) & ((uint32_t) (__SIZE_WIDTH__ - 1));
+        (lg - (uint32_t) SL_SHIFT) & ((uint32_t) (_TLSF_SIZE_WIDTH - 1));
     size_t round = is_large << shift;
     /* Large: (1 << shift) - 1 = SL rounding mask.  Small: 0 - 0 = 0. */
     size_t t = round - is_large;
@@ -341,7 +387,14 @@ INLINE void mapping(size_t size, uint32_t *fl, uint32_t *sl)
     /* All-ones mask when size is in the linear range (< BLOCK_SIZE_SMALL),
      * all-zeros when in the logarithmic range.
      */
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4146)
+#endif
     uint32_t small = -(uint32_t) (t < (uint32_t) FL_SHIFT);
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
     /* FL: 0 for small sizes, (t - FL_SHIFT + 1) for large sizes.
      * The wrapping subtraction when t < FL_SHIFT is harmless because
@@ -354,7 +407,7 @@ INLINE void mapping(size_t size, uint32_t *fl, uint32_t *sl)
      * the garbage result is masked out by `small`.
      */
     uint32_t shift =
-        (t - (uint32_t) SL_SHIFT) & ((uint32_t) (__SIZE_WIDTH__ - 1));
+        (t - (uint32_t) SL_SHIFT) & ((uint32_t) (_TLSF_SIZE_WIDTH - 1));
     uint32_t sl_large = (uint32_t) (size >> shift) ^ SL_COUNT;
     uint32_t sl_small = (uint32_t) (size >> ALIGN_SHIFT);
     *sl = (~small & sl_large) | (small & sl_small);

--- a/tests/test.c
+++ b/tests/test.c
@@ -10,9 +10,16 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#if defined(_WIN32) || defined(WIN32) || defined(__WIN32__) || defined(_WIN64)
+#include <windows.h>
+#include <stddef.h>
+#include <time.h>
+#else
 #include <sys/mman.h>
 #include <time.h>
 #include <unistd.h>
+#endif
+
 
 #include "tlsf.h"
 
@@ -21,6 +28,60 @@ static size_t MAX_PAGES;
 static size_t curr_pages = 0;
 static void *start_addr = 0;
 
+#if defined(_WIN32) || defined(WIN32) || defined(__WIN32__) || defined(_WIN64)
+size_t get_page_size(void)
+{
+    SYSTEM_INFO si;
+    GetSystemInfo(&si);
+    return (size_t)si.dwPageSize;
+}
+
+void* tlsf_resize(tlsf_t* t, size_t req_size)
+{
+    (void)t;
+
+    // This is analogue mmap with flag MAP_NORESERVE to VirtualAlloc with MEM_RESERVE
+    if (!start_addr) {
+        start_addr = VirtualAlloc(
+            NULL,
+            MAX_PAGES * PAGE,
+            MEM_RESERVE,    // Only reserve address space 
+            PAGE_READWRITE       // Rights for read and write 
+        );
+        if (!start_addr) return NULL;
+    }
+
+    size_t req_pages = (req_size + PAGE - 1) / PAGE;
+    if (req_pages > MAX_PAGES)
+        return NULL;
+
+    if (req_pages != curr_pages) {
+        if (req_pages < curr_pages) {
+            // Analogue for madvise(..., MADV_DONTNEED) to VirtualFree with MEM_DECOMMIT
+            // Free physical memory (commit), with reserved addresses
+            VirtualFree(
+                (char*)start_addr + PAGE * req_pages,
+                (size_t)(curr_pages - req_pages) * PAGE,
+                MEM_DECOMMIT     // physical pages to zero
+            );
+        }
+        else {
+            // Commit reserved memory            
+            void* commit_ptr = VirtualAlloc(
+                start_addr,      // base address is the same
+                req_pages * PAGE,
+                MEM_COMMIT,      // Commit new pages
+                PAGE_READWRITE
+            );
+            if (!commit_ptr) return NULL;
+        }
+
+        curr_pages = req_pages;
+    }
+
+    return start_addr;
+}
+#else
 void *tlsf_resize(tlsf_t *t, size_t req_size)
 {
     (void) t;
@@ -42,6 +103,7 @@ void *tlsf_resize(tlsf_t *t, size_t req_size)
 
     return start_addr;
 }
+#endif
 
 static void random_test(tlsf_t *t, size_t spacelen, const size_t cap)
 {
@@ -125,16 +187,28 @@ static void random_test(tlsf_t *t, size_t spacelen, const size_t cap)
 
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof(x[0]))
 
+#if defined(_MSC_VER)
+static int msvc_large_rand(void)
+{
+    // 1 billion random number for MSVC
+    return (rand() << 15) | rand();
+}
+#endif
+
 static void random_sizes_test(tlsf_t *t)
 {
-    const size_t sizes[] = {16, 32, 64, 128, 256, 512, 1024, 1024 * 1024};
+    const size_t sizes[] = { 16, 32, 64, 128, 256, 512, 1024, 1024 * 1024 };
 
     printf("Random allocation test: ");
     for (unsigned i = 0; i < ARRAY_SIZE(sizes); i++) {
         unsigned n = 1024;
 
         while (n--)
-            random_test(t, sizes[i], (size_t) rand() % sizes[i] + 1);
+#if defined(_MSC_VER)
+            random_test(t, sizes[i], (size_t)msvc_large_rand() % sizes[i] + 1);
+#else
+            random_test(t, sizes[i], (size_t)rand() % sizes[i] + 1);
+#endif
         printf(".");
         fflush(stdout);
     }
@@ -168,7 +242,7 @@ static void large_size_test(tlsf_t *t)
     /* Cap test size to fit within test pool limits.
      * 64-bit: up to 256MB, 32-bit: up to 32MB (pool is 128MB)
      */
-#if __SIZE_WIDTH__ == 64 || defined(__LP64__) || defined(_LP64)
+#if _TLSF_SIZE_WIDTH == 64 || defined(__LP64__) || defined(_LP64)
     size_t max_test = (size_t) 1 << 28; /* 256 MB */
 #else
     size_t max_test = (size_t) 1 << 25; /* 32 MB */
@@ -179,7 +253,7 @@ static void large_size_test(tlsf_t *t)
     size_t s = 1;
     while (s <= max_test) {
         large_alloc(t, s);
-        s *= 2;
+        s *= 2;        
     }
     printf(".");
     fflush(stdout);
@@ -893,12 +967,16 @@ static void pool_reset_test(void)
 
 int main(void)
 {
+#ifdef _WIN32
+    PAGE = get_page_size();
+#else
     PAGE = (size_t) sysconf(_SC_PAGESIZE);
+#endif
     /* Virtual address space reservation for testing.
      * 64-bit: 1GB is sufficient and safe
      * 32-bit: 128MB to avoid VA space exhaustion (user space is 2-3GB)
      */
-#if __SIZE_WIDTH__ == 64 || defined(__LP64__) || defined(_LP64)
+#if _TLSF_SIZE_WIDTH == 64 || defined(__LP64__) || defined(_LP64)
     MAX_PAGES = ((size_t) 1 << 30) / PAGE; /* 1 GB */
 #else
     MAX_PAGES = ((size_t) 128 << 20) / PAGE; /* 128 MB */

--- a/tests/test_thread.c
+++ b/tests/test_thread.c
@@ -61,7 +61,7 @@ static tlsf_thread_t ts;
 #if defined(_MSC_VER)
 #define TLSF_RAND(x) (rand_s((x)), (unsigned)*(x))
 #else
-#define TLSF_RAND(x) rand_r(x)
+#define TLSF_RAND(x) (rand_r(x))
 #endif
 
 /* ------------------------------------------------------------------ */

--- a/tests/test_thread.c
+++ b/tests/test_thread.c
@@ -11,10 +11,15 @@
  */
 
 #include <assert.h>
-#include <pthread.h>
+//#include <pthread.h>
 #include <stdint.h>
 #include <stdio.h>
+#if defined(_MSC_VER)
+#define _CRT_RAND_S
 #include <stdlib.h>
+#else
+#include <stdlib.h>
+#endif
 #include <string.h>
 
 #include "tlsf_thread.h"
@@ -29,8 +34,24 @@
 #define MAX_ALLOCS 128
 #define MAX_ALLOC_SIZE 2048
 
-static char pool[POOL_SIZE] __attribute__((aligned(16)));
+TLSF_MSVC_ALIGN(16) static char pool[POOL_SIZE] TLSF_GCC_ALIGN(16);
 static tlsf_thread_t ts;
+
+#if defined(USE_C11_THREADS)
+#define TLSF_THREAD_T thrd_t
+#define TLSF_CREATE_THREAD(thrd, func, arg) thrd_create(thrd, func, arg)
+#define TLSF_JOIN_THREAD thrd_join
+#else
+#define TLSF_THREAD_T pthread_t
+#define TLSF_CREATE_THREAD(thrd, func, arg) pthread_create(thrd, NULL, func, arg)
+#define TLSF_JOIN_THREAD pthread_join
+#endif
+
+#if defined(_MSC_VER)
+#define TLSF_RAND rand_s
+#else
+#define TLSF_RAND rand_r
+#endif
 
 /* ------------------------------------------------------------------ */
 /* Per-thread work                                                     */
@@ -55,13 +76,13 @@ static void *thread_func(void *arg)
     memset(ptrs, 0, sizeof(ptrs));
 
     for (int op = 0; op < OPS_PER_THREAD; op++) {
-        int action = (int) (rand_r(&seed) % 4);
+        int action = (int) (TLSF_RAND(&seed) % 4);
 
         switch (action) {
         case 0: /* malloc */
         case 1:
             if (count < MAX_ALLOCS) {
-                size_t sz = (size_t) (rand_r(&seed) % MAX_ALLOC_SIZE) + 1;
+                size_t sz = (size_t) (TLSF_RAND(&seed) % MAX_ALLOC_SIZE) + 1;
                 void *p = tlsf_thread_malloc(&ts, sz);
                 if (p) {
                     /* Fill with per-thread pattern for integrity check */
@@ -76,7 +97,7 @@ static void *thread_func(void *arg)
 
         case 2: /* free */
             if (count > 0) {
-                int idx = (int) ((unsigned) rand_r(&seed) % (unsigned) count);
+                int idx = (int) ((unsigned) TLSF_RAND(&seed) % (unsigned) count);
                 /* Verify fill pattern before freeing */
                 uint8_t *data = (uint8_t *) ptrs[idx];
                 for (size_t i = 0; i < sizes[idx]; i++) {
@@ -96,9 +117,9 @@ static void *thread_func(void *arg)
 
         case 3: /* realloc */
             if (count > 0) {
-                int idx = (int) ((unsigned) rand_r(&seed) % (unsigned) count);
+                int idx = (int) ((unsigned) TLSF_RAND(&seed) % (unsigned) count);
                 size_t old_sz = sizes[idx];
-                size_t new_sz = (size_t) (rand_r(&seed) % MAX_ALLOC_SIZE) + 1;
+                size_t new_sz = (size_t) (TLSF_RAND(&seed) % MAX_ALLOC_SIZE) + 1;
 
                 void *p = tlsf_thread_realloc(&ts, ptrs[idx], new_sz);
                 if (p) {
@@ -152,7 +173,7 @@ static void stress_test(void)
     printf("(%d arenas, %zu usable) ", ts.count, usable);
     fflush(stdout);
 
-    pthread_t threads[NUM_THREADS];
+    TLSF_THREAD_T threads[NUM_THREADS];
     thread_result_t results[NUM_THREADS];
 
     for (int i = 0; i < NUM_THREADS; i++) {
@@ -161,13 +182,13 @@ static void stress_test(void)
         results[i].alloc_count = 0;
         results[i].free_count = 0;
         results[i].realloc_count = 0;
-        pthread_create(&threads[i], NULL, thread_func, &results[i]);
+        TLSF_CREATE_THREAD(&threads[i], thread_func, &results[i]);
     }
 
     int total_errors = 0;
     int total_allocs = 0, total_frees = 0, total_reallocs = 0;
     for (int i = 0; i < NUM_THREADS; i++) {
-        pthread_join(threads[i], NULL);
+        TLSF_JOIN_THREAD(threads[i], NULL);
         total_errors += results[i].errors;
         total_allocs += results[i].alloc_count;
         total_frees += results[i].free_count;
@@ -201,11 +222,11 @@ static void *aligned_thread_func(void *arg)
 
     for (int op = 0; op < 5000; op++) {
         /* Alignment: power of two from 8 to 4096 */
-        unsigned shift = (unsigned) (rand_r(&seed) % 10) + 3; /* 8 to 8192 */
+        unsigned shift = (unsigned) (TLSF_RAND(&seed) % 10) + 3; /* 8 to 8192 */
         size_t align = (size_t) 1 << shift;
         if (align > 4096)
             align = 4096;
-        size_t sz = (size_t) (rand_r(&seed) % 512) + 1;
+        size_t sz = (size_t) (TLSF_RAND(&seed) % 512) + 1;
 
         void *p = tlsf_thread_aalloc(&ts, align, sz);
         if (p) {
@@ -225,14 +246,14 @@ static void aligned_test(void)
     size_t usable = tlsf_thread_init(&ts, pool, sizeof(pool));
     assert(usable > 0);
 
-    pthread_t threads[NUM_THREADS];
+    TLSF_THREAD_T threads[NUM_THREADS];
     int ids[NUM_THREADS];
     for (int i = 0; i < NUM_THREADS; i++) {
         ids[i] = i;
-        pthread_create(&threads[i], NULL, aligned_thread_func, &ids[i]);
+        TLSF_CREATE_THREAD(&threads[i], aligned_thread_func, &ids[i]);
     }
     for (int i = 0; i < NUM_THREADS; i++)
-        pthread_join(threads[i], NULL);
+        TLSF_JOIN_THREAD(threads[i], NULL);
 
     tlsf_thread_check(&ts);
 

--- a/tests/test_thread.c
+++ b/tests/test_thread.c
@@ -41,7 +41,6 @@ static tlsf_thread_t ts;
 #define TLSF_THREAD_T thrd_t
 #define TLSF_CREATE_THREAD(thrd, func, arg) thrd_create(thrd, func, arg)
 #define TLSF_JOIN_THREAD(thrd) thrd_join((thrd), NULL)
-#define TLSF_JOIN_THREAD(thrd) thrd_join((thrd), NULL)
 #define TLSF_THREAD_CONVENTION int
 #define TLSF_THREAD_RETURN 0
 #elif defined(TLSF_THREAD_POSIX)

--- a/tests/test_thread.c
+++ b/tests/test_thread.c
@@ -40,11 +40,16 @@ static tlsf_thread_t ts;
 #if defined(USE_C11_THREADS)
 #define TLSF_THREAD_T thrd_t
 #define TLSF_CREATE_THREAD(thrd, func, arg) thrd_create(thrd, func, arg)
-#define TLSF_JOIN_THREAD thrd_join
-#else
+#define TLSF_JOIN_THREAD(thrd) thrd_join((thrd), NULL)
+#elif defined(TLSF_THREAD_POSIX)
 #define TLSF_THREAD_T pthread_t
 #define TLSF_CREATE_THREAD(thrd, func, arg) pthread_create(thrd, NULL, func, arg)
-#define TLSF_JOIN_THREAD pthread_join
+#define TLSF_JOIN_THREAD(thrd) pthread_join((thrd), NULL)
+#elif defined(TLSF_THREAD_WIN)
+#define TLSF_THREAD_T HANDLE
+#define TLSF_CREATE_THREAD(thrd, func, arg) \
+    ((*(thrd) = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)(func), (arg), 0, NULL)) != NULL ? 0 : -1)
+#define TLSF_JOIN_THREAD(thrd) (WaitForSingleObject((thrd), INFINITE), CloseHandle((thrd)), 0)
 #endif
 
 #if defined(_MSC_VER)
@@ -188,7 +193,7 @@ static void stress_test(void)
     int total_errors = 0;
     int total_allocs = 0, total_frees = 0, total_reallocs = 0;
     for (int i = 0; i < NUM_THREADS; i++) {
-        TLSF_JOIN_THREAD(threads[i], NULL);
+        TLSF_JOIN_THREAD(threads[i]);
         total_errors += results[i].errors;
         total_allocs += results[i].alloc_count;
         total_frees += results[i].free_count;
@@ -253,7 +258,7 @@ static void aligned_test(void)
         TLSF_CREATE_THREAD(&threads[i], aligned_thread_func, &ids[i]);
     }
     for (int i = 0; i < NUM_THREADS; i++)
-        TLSF_JOIN_THREAD(threads[i], NULL);
+        TLSF_JOIN_THREAD(threads[i]);
 
     tlsf_thread_check(&ts);
 

--- a/tests/test_thread.c
+++ b/tests/test_thread.c
@@ -59,9 +59,9 @@ static tlsf_thread_t ts;
 #endif
 
 #if defined(_MSC_VER)
-#define TLSF_RAND rand_s
+#define TLSF_RAND(x) (rand_s((x)), (unsigned)*(x))
 #else
-#define TLSF_RAND rand_r
+#define TLSF_RAND(x) rand_r(x)
 #endif
 
 /* ------------------------------------------------------------------ */

--- a/tests/test_thread.c
+++ b/tests/test_thread.c
@@ -41,15 +41,22 @@ static tlsf_thread_t ts;
 #define TLSF_THREAD_T thrd_t
 #define TLSF_CREATE_THREAD(thrd, func, arg) thrd_create(thrd, func, arg)
 #define TLSF_JOIN_THREAD(thrd) thrd_join((thrd), NULL)
+#define TLSF_JOIN_THREAD(thrd) thrd_join((thrd), NULL)
+#define TLSF_THREAD_CONVENTION int
+#define TLSF_THREAD_RETURN 0
 #elif defined(TLSF_THREAD_POSIX)
 #define TLSF_THREAD_T pthread_t
 #define TLSF_CREATE_THREAD(thrd, func, arg) pthread_create(thrd, NULL, func, arg)
 #define TLSF_JOIN_THREAD(thrd) pthread_join((thrd), NULL)
+#define TLSF_THREAD_CONVENTION void*
+#define TLSF_THREAD_RETURN NULL
 #elif defined(TLSF_THREAD_WIN)
 #define TLSF_THREAD_T HANDLE
 #define TLSF_CREATE_THREAD(thrd, func, arg) \
     ((*(thrd) = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)(func), (arg), 0, NULL)) != NULL ? 0 : -1)
 #define TLSF_JOIN_THREAD(thrd) (WaitForSingleObject((thrd), INFINITE), CloseHandle((thrd)), 0)
+#define TLSF_THREAD_CONVENTION DWORD WINAPI
+#define TLSF_THREAD_RETURN 0
 #endif
 
 #if defined(_MSC_VER)
@@ -70,7 +77,7 @@ typedef struct {
     int realloc_count; /* total reallocs */
 } thread_result_t;
 
-static void *thread_func(void *arg)
+static TLSF_THREAD_CONVENTION thread_func(void *arg)
 {
     thread_result_t *res = (thread_result_t *) arg;
     void *ptrs[MAX_ALLOCS];
@@ -160,7 +167,7 @@ static void *thread_func(void *arg)
         tlsf_thread_free(&ts, ptrs[i]);
     }
 
-    return NULL;
+    return TLSF_THREAD_RETURN;
 }
 
 /* ------------------------------------------------------------------ */
@@ -220,7 +227,7 @@ static void stress_test(void)
 /* Test: aligned allocation under contention                           */
 /* ------------------------------------------------------------------ */
 
-static void *aligned_thread_func(void *arg)
+static TLSF_THREAD_CONVENTION aligned_thread_func(void *arg)
 {
     int id = *(int *) arg;
     unsigned seed = (unsigned) id * 0xDEADBEEF + 7;
@@ -240,7 +247,7 @@ static void *aligned_thread_func(void *arg)
             tlsf_thread_free(&ts, p);
         }
     }
-    return NULL;
+    return TLSF_THREAD_RETURN;
 }
 
 static void aligned_test(void)


### PR DESCRIPTION
Hello. This PR adds compatibility for Windows and Visual C++. It adds compatibility for tlsf, tlsf_thread, test and test_thread. Benchmarks are left as is.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Windows/MSVC support to `tlsf`, `tlsf_thread`, and tests, and adds a Windows CI job that builds and runs both single- and multi‑threaded tests. Previously Windows was unsupported and threads were POSIX-only; now MSVC prefers C11 threads when available, otherwise Win32, and we restore a safe `TLSF_THREAD_HINT` fallback while fixing a `log2floor` regression.

- Threads/locks: unify C11/POSIX/Win32 backends; fix `TLSF_THREAD_T` selection; prefer C11 on MSVC with `/std:c11` (VS 2022 17.5+), else Win32; `TLSF_THREAD_HINT` uses `GetCurrentThreadId` or 0U fallback.
- Portability: replace `__SIZE_WIDTH__` with `_TLSF_SIZE_WIDTH`; make `UNLIKELY`/`INLINE` MSVC-safe; use `_BitScan*` intrinsics; add `TLSF_MSVC_ALIGN`/`TLSF_GCC_ALIGN`; add `TLSF_INIT_STATIC`; provide default `tlsf_resize` via weak symbol (GCC/Clang) or MSVC linker alias.
- Tests: on Windows use `VirtualAlloc`/`VirtualFree` with commit/decommit; unify thread create/join for C11/POSIX/Win32; add `TLSF_RAND` (`rand_s` on MSVC, `rand_r` elsewhere); fix calling conventions and alignments.
- CI: add an MSVC job on `windows-latest` that compiles and runs both single- and multi-threaded tests; fix ensures all tests run.

**Migration**
- Windows/MSVC: VS 2022 17.5+ with `/std:c11` enables the C11 threads backend; otherwise Win32 is used. Define `TLSF_C11_THREADS` to force C11 where supported.
- MSVC: initialize static `tlsf_t` with `TLSF_INIT_STATIC`.

<sup>Written for commit b0c4082d4aa6e58e9c2c35891fa4c14933f80a77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/tlsf-bsd/pull/23?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

