### PR TITLE
Fixes the Windows MSVC CI regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
   build-windows-msvc:
     needs: coding-style
     runs-on: windows-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - name: Setup MSVC Developer Command Prompt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
       - name: Compile Single-Threaded TLSF with MSVC
         run: |
-          cl.exe /Iinclude /O2 /W3 /DTLSF_ENABLE_ASSERT /DTLSF_ENABLE_CHECK src\tlsf.c tests\test.c /Fe:test_tlsf.exe
+          cl.exe /Iinclude /O2 /W3 /std:c11 /DTLSF_ENABLE_ASSERT /DTLSF_ENABLE_CHECK src\tlsf.c tests\test.c /Fe:test_tlsf.exe
       - name: Run Single-Threaded Tests
         run: |
           .\test_tlsf.exe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,34 @@ jobs:
           - runner: ubuntu-24.04-arm
             cc: gcc
             cflags: "-fsanitize=address,undefined"
+          # ThreadSanitizer: the only sanitizer that sees races in the
+          # per-arena locking of src/tlsf_thread.c. ASan does not.
+          - runner: ubuntu-24.04
+            cc: clang
+            cflags: "-fsanitize=thread"
+          - runner: ubuntu-24.04-arm
+            cc: gcc
+            cflags: "-fsanitize=thread"
+          # Compile-time configuration knobs. Without these the reduced-pool
+          # and split-threshold paths rot untested.
+          - runner: ubuntu-24.04
+            cc: gcc
+            cflags: "-DTLSF_MAX_POOL_BITS=20"
+          - runner: ubuntu-24.04
+            cc: clang
+            cflags: "-DTLSF_MAX_POOL_BITS=24 -fsanitize=address,undefined"
+          - runner: ubuntu-24.04
+            cc: gcc
+            cflags: "-DTLSF_SPLIT_THRESHOLD=64"
+          # Portable bit-scan fallbacks used by toolchains without
+          # __builtin_ctz / _BitScanForward. Unreachable on these runners
+          # unless forced.
+          - runner: ubuntu-24.04
+            cc: gcc
+            cflags: "-DTLSF_NO_INTRINSICS"
+          - runner: ubuntu-24.04
+            cc: clang
+            cflags: "-DTLSF_NO_INTRINSICS -fsanitize=address,undefined"
     steps:
       - uses: actions/checkout@v6
       - name: Build
@@ -75,6 +103,27 @@ jobs:
           CC: ${{ matrix.cc }}
           CFLAGS: ${{ matrix.cflags }}
   
+  # 32-bit build: exercises the _TLSF_SIZE_WIDTH == 32 paths (ALIGN_SHIFT 2,
+  # _TLSF_FL_MAX 31, __builtin_clzl) that the 64-bit matrix never compiles.
+  build-32bit:
+    needs: coding-style
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install multilib toolchain
+        run: sudo apt-get update && sudo apt-get install -y gcc-multilib
+        env:
+          DEBIAN_FRONTEND: noninteractive
+      - name: Build
+        run: make all
+        env:
+          CFLAGS: "-m32"
+      - name: Test
+        run: make check
+        env:
+          CFLAGS: "-m32"
+
   build-windows-msvc:
     needs: coding-style
     runs-on: windows-latest

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 build/
 tags
 core
+*.dSYM/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ therefore no GPL restrictions apply.
 * Branch-free size-to-bin mapping
 * Optional thread-safe wrapper (`tlsf_thread.h`)
   with per-arena fine-grained locking and configurable lock primitives for RTOS portability
-* ~500 lines of core allocator code
+* ~1400 lines of core allocator code
 * Minimal libc: only `stddef.h`, `stdbool.h`, `stdint.h`, `string.h`
 
 ## Build and Test
@@ -319,12 +319,49 @@ Fewer arenas improve memory utilization at the cost of higher contention.
 
 | Constant | 64-bit | 32-bit | Notes |
 |----------|--------|--------|-------|
-| `TLSF_MAX_SIZE` | ~274 GB | ~2 GB | Reduced by `TLSF_MAX_POOL_BITS` |
+| `TLSF_MAX_SIZE` | 256 GiB - 8 | 1 GiB - 4 | Largest single allocation; reduced by `TLSF_MAX_POOL_BITS` |
+| `TLSF_MAX_POOL_BYTES` | 256 GiB + 16 | 1 GiB + 8 | Largest region `tlsf_pool_init()` accepts |
 | FL classes | 32 | 25 | `_TLSF_FL_MAX - _TLSF_FL_SHIFT + 1` |
 | Alignment | 8 bytes | 4 bytes | |
-| Min block | 16 bytes | 12 bytes | |
+| Min block | 24 bytes | 12 bytes | `sizeof(tlsf_block) - sizeof(ptr)` |
 | Block overhead | 8 bytes | 4 bytes | |
 | SL subdivisions | 32 | 32 | |
+
+### Control structure size
+
+`tlsf_t` is caller-allocated and holds the full `FL x SL` bin array, so its size
+is set entirely by the configuration. The 32x32 default trades memory for a
+worst-case internal fragmentation of 3.125% instead of the 6.25% a 16-wide
+second level would give.
+
+| Configuration | 64-bit `tlsf_t` | Bins | Max pool |
+|---------------|-----------------|------|----------|
+| Default (`_TLSF_FL_MAX` 39) | 8,376 bytes | 1024 | 512 GB |
+| `-DTLSF_MAX_POOL_BITS=24` | 4,480 bytes | 544 | 16 MB |
+| `-DTLSF_MAX_POOL_BITS=20` | 3,440 bytes | 416 | 1 MB |
+| `-DTLSF_MAX_POOL_BITS=18` | 2,920 bytes | 352 | 256 KB |
+
+Smaller values still work; 18 is simply the floor the bundled test suite is
+parameterized for.
+
+`tlsf_thread_t` is roughly `TLSF_ARENA_COUNT` times that, but its exact size
+depends on the platform's lock type, so it is not quoted as a single number
+here. Each arena is padded to `TLSF_CACHELINE_SIZE`:
+
+```
+arena = round_up(sizeof(tlsf_t) + sizeof(TLSF_LOCK_T) + 2 * sizeof(void *),
+                 TLSF_CACHELINE_SIZE)
+total = round_up(arena * TLSF_ARENA_COUNT + sizeof(int), TLSF_CACHELINE_SIZE)
+```
+
+With the default configuration and four arenas that is 34,112 bytes where
+`pthread_mutex_t` is 64 bytes (macOS) and 33,856 where it is 40 bytes (glibc
+x86-64). Print `sizeof(tlsf_thread_t)` on your target rather than relying on
+either figure.
+
+Note that `TLSF_MAX_POOL_BITS` changes the layout of a struct that callers
+allocate themselves. Every translation unit in a build must be compiled with an
+identical set of configuration macros; a mismatch is not diagnosed.
 
 ## WCET Measurement
 

--- a/include/tlsf.h
+++ b/include/tlsf.h
@@ -14,6 +14,7 @@
 extern "C" {
 #endif /* __cplusplus */
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -95,7 +96,13 @@ struct tlsf_block {
 
 typedef struct {
     uint32_t fl, sl[_TLSF_FL_COUNT];
-    void *arena; /* Pool base address; non-NULL for fixed pools */
+
+    /* Fixed pool: memory is caller-owned (tlsf_pool_init) and the arena can
+     * neither grow nor shrink. Orthogonal to `arena`, which is always the
+     * current base address once the pool has any memory.
+     */
+    bool fixed;
+    void *arena; /* Pool base address; NULL until a dynamic pool first grows */
     size_t size;
     struct tlsf_block *block[_TLSF_FL_COUNT][_TLSF_SL_COUNT];
     struct tlsf_block block_null; /* Free-list sentinel (absorbs writes) */

--- a/include/tlsf.h
+++ b/include/tlsf.h
@@ -68,6 +68,17 @@ extern "C" {
 #endif
 #define _TLSF_FL_COUNT (_TLSF_FL_MAX - _TLSF_FL_SHIFT + 1)
 #define TLSF_MAX_SIZE (((size_t) 1 << (_TLSF_FL_MAX - 1)) - sizeof(size_t))
+
+/* Largest region tlsf_pool_init() accepts, for an ALIGN_SIZE-aligned pointer.
+ * The pool's single initial free block cannot exceed 2^(_TLSF_FL_MAX - 1)
+ * bytes, and the pool also carries that block's header and a sentinel.
+ *
+ * A region is accepted when its size, rounded down to the alignment, is at
+ * most this; a few trailing bytes past it are tolerated and ignored. Note this
+ * is about half of 2^_TLSF_FL_MAX, which bounds a *dynamic* arena instead.
+ */
+#define TLSF_MAX_POOL_BYTES \
+    (((size_t) 1 << (_TLSF_FL_MAX - 1)) + 2 * sizeof(size_t))
 #define TLSF_INIT ((tlsf_t) {.size = 0})
 
 /* TLSF_INIT_STATIC is need to be used instead of TLSF_INIT for initializing

--- a/include/tlsf.h
+++ b/include/tlsf.h
@@ -18,6 +18,27 @@ extern "C" {
 #include <stddef.h>
 #include <stdint.h>
 
+/* IMPORTANT: the configuration macros below (TLSF_MAX_POOL_BITS in particular)
+ * change the layout and size of tlsf_t, which callers allocate themselves.
+ * Every translation unit in a build -- src/tlsf.c and every consumer -- must
+ * see identical definitions. A mismatch is not diagnosed: the struct silently
+ * differs in size (8376 vs 3440 bytes for the default vs TLSF_MAX_POOL_BITS=20
+ * on 64-bit) and accesses land at the wrong offsets. Define them in the build
+ * system, never in a single .c file.
+ *
+ * TLSF_ENABLE_CHECK is a special case, and it is only half-safe. tlsf_check()
+ * is an extern function when it is defined and a static inline no-op when it
+ * is not, so a mismatch behaves differently depending on which side has it:
+ *
+ *   consumer has it, tlsf.c does not -> undefined reference at link time
+ *   tlsf.c has it, consumer does not -> links fine, and every tlsf_check()
+ *                                       call in the consumer silently becomes
+ *                                       a no-op
+ *
+ * The second direction produces no diagnostic at all: the heap checking a
+ * caller believes is enabled simply is not running. Set it uniformly.
+ */
+
 /* Second-level subdivisions: 32 bins per first-level class. Max internal
  * fragmentation bounded by 1/SL_COUNT = 3.125% (was 6.25% with 16 bins).
  * Control structure size increases ~2x for the block pointer array.

--- a/include/tlsf_thread.h
+++ b/include/tlsf_thread.h
@@ -48,9 +48,14 @@ extern "C" {
  * providing custom locks, also define TLSF_THREAD_HINT() to return a
  * thread-specific unsigned integer for arena selection.
  *
+ * TLSF_LOCK_INIT must evaluate to an int: 0 on success, non-zero on failure.
+ * tlsf_thread_init() checks it and aborts initialization if a lock cannot be
+ * created. The other five macros are used as statements or as a boolean
+ * (TLSF_LOCK_TRY) and their values are otherwise ignored.
+ *
  * Example (FreeRTOS):
  *   #define TLSF_LOCK_T           SemaphoreHandle_t
- *   #define TLSF_LOCK_INIT(l)     (*(l) = xSemaphoreCreateMutex())
+ *   #define TLSF_LOCK_INIT(l)     ((*(l) = xSemaphoreCreateMutex()) ? 0 : -1)
  *   #define TLSF_LOCK_DESTROY(l)  vSemaphoreDelete(*(l))
  *   #define TLSF_LOCK_ACQUIRE(l)  xSemaphoreTake(*(l), portMAX_DELAY)
  *   #define TLSF_LOCK_RELEASE(l)  xSemaphoreGive(*(l))
@@ -103,7 +108,8 @@ extern "C" {
 
 #if defined(USE_C11_THREADS)
 #define TLSF_LOCK_T mtx_t
-#define TLSF_LOCK_INIT(l) mtx_init((l), mtx_plain)
+/* C11 does not require thrd_success to be 0, so normalize it. */
+#define TLSF_LOCK_INIT(l) (mtx_init((l), mtx_plain) == thrd_success ? 0 : -1)
 #define TLSF_LOCK_DESTROY(l) mtx_destroy((l))
 #define TLSF_LOCK_ACQUIRE(l) mtx_lock((l))
 #define TLSF_LOCK_RELEASE(l) mtx_unlock((l))
@@ -262,6 +268,10 @@ void tlsf_thread_check(tlsf_thread_t *ts);
 /**
  * Aggregate statistics across all arenas. largest_free reports the single
  * largest free block in any arena.
+ *
+ * Not an atomic snapshot: arena locks are taken one at a time, so concurrent
+ * allocations in an already-visited arena are not reflected. Quiesce the other
+ * threads first if you need an exact figure.
  */
 int tlsf_thread_stats(tlsf_thread_t *ts, tlsf_stats_t *stats);
 

--- a/src/tlsf.c
+++ b/src/tlsf.c
@@ -120,6 +120,12 @@
  */
 #define BLOCK_PAYLOAD_OVERHEAD (sizeof(struct tlsf_block *) * 3)
 
+/* Forcing always_inline costs 168 bytes of .text over plain `static inline` at
+ * -O2 (6236 vs 6068, clang/arm64), because the compiler already inlines these
+ * helpers on its own. Median malloc_worst latency is identical at 42 ticks
+ * either way; the tails are scheduler noise. Override with -DINLINE="static
+ * inline" if a target's icache budget says otherwise.
+ */
 #ifndef INLINE
 #if defined(__GNUC__) || defined(__MINGW32__) || defined(__MINGW64__) || \
     defined(__clang__)
@@ -377,7 +383,7 @@ INLINE tlsf_block_t *block_link_next(tlsf_block_t *block)
     return next;
 }
 
-INLINE bool block_can_split(tlsf_block_t *block, size_t size)
+INLINE bool block_can_split(const tlsf_block_t *block, size_t size)
 {
     return block_size(block) >= sizeof(tlsf_block_t) + size;
 }
@@ -385,7 +391,7 @@ INLINE bool block_can_split(tlsf_block_t *block, size_t size)
 /* When trimming, require the remainder to be at least TLSF_SPLIT_THRESHOLD to
  * avoid creating tiny free blocks that waste metadata overhead.
  */
-INLINE bool block_can_trim(tlsf_block_t *block, size_t size)
+INLINE bool block_can_trim(const tlsf_block_t *block, size_t size)
 {
     return block_size(block) >= BLOCK_OVERHEAD + TLSF_SPLIT_THRESHOLD + size;
 }
@@ -596,7 +602,7 @@ INLINE tlsf_block_t *block_split(tlsf_block_t *block, size_t size)
 }
 
 /* Absorb a free block's storage into an adjacent previous free block. */
-INLINE tlsf_block_t *block_absorb(tlsf_block_t *prev, tlsf_block_t *block)
+INLINE tlsf_block_t *block_absorb(tlsf_block_t *prev, const tlsf_block_t *block)
 {
     ASSERT(block_size(prev), "previous block can't be last");
     /* Note: Leaves flags untouched. */
@@ -688,6 +694,37 @@ INLINE void check_sentinel(tlsf_block_t *block)
     ASSERT(!block_is_free(block), "sentinel block should not be free");
 }
 
+/* Point every bin at the free-list sentinel and clear the bitmaps, so that
+ * insert/remove can write unconditionally without a NULL check. Cost is a fixed
+ * O(FL_COUNT * SL_COUNT) regardless of how much is allocated.
+ */
+static void bins_reset(tlsf_t *t)
+{
+    t->fl = 0;
+    memset(t->sl, 0, sizeof(t->sl));
+    for (uint32_t i = 0; i < FL_COUNT; i++)
+        for (uint32_t j = 0; j < SL_COUNT; j++)
+            t->block[i][j] = &t->block_null;
+}
+
+/* Lay out a pool as a single free block of `free_size` payload bytes followed
+ * by the terminating zero-size sentinel. `start` is the first payload byte; the
+ * block header sits one word below it, and that block's prev field lies outside
+ * the pool and is never read.
+ */
+static void pool_build(tlsf_t *t, char *start, size_t free_size)
+{
+    tlsf_block_t *block = to_block(start - BLOCK_OVERHEAD);
+    block->header = free_size | BLOCK_BIT_FREE;
+    block_insert(t, block);
+
+    tlsf_block_t *sentinel = block_link_next(block);
+    sentinel->header = BLOCK_BIT_PREV_FREE;
+    check_sentinel(sentinel);
+
+    block_poison_free(block);
+}
+
 static bool arena_grow(tlsf_t *t, size_t size)
 {
     /* Fixed pools cannot grow. */
@@ -697,11 +734,8 @@ static bool arena_grow(tlsf_t *t, size_t size)
     /* First use of a dynamic pool: point all empty-bin pointers at the sentinel
      * so that insert/remove can write unconditionally.
      */
-    if (!t->size) {
-        for (uint32_t i = 0; i < FL_COUNT; i++)
-            for (uint32_t j = 0; j < SL_COUNT; j++)
-                t->block[i][j] = &t->block_null;
-    }
+    if (!t->size)
+        bins_reset(t);
 
     size_t req_size =
         (t->size ? t->size + BLOCK_OVERHEAD : 2 * BLOCK_OVERHEAD) + size;
@@ -751,8 +785,8 @@ static size_t arena_append_pool(tlsf_t *t, void *mem, size_t size)
         return 0;
 
     /* Align memory block boundaries */
-    char *start = align_ptr((char *) mem, ALIGN_SIZE);
-    char *end = (char *) mem + size;
+    const char *start = align_ptr((char *) mem, ALIGN_SIZE);
+    const char *end = (char *) mem + size;
     size_t aligned_size = (size_t) (end - start) & ~(ALIGN_SIZE - 1);
 
     /* For fixed pools, the new sentinel must fit within the appended region
@@ -772,7 +806,7 @@ static size_t arena_append_pool(tlsf_t *t, void *mem, size_t size)
     if (!current_pool_start)
         return 0;
 
-    char *current_pool_end = (char *) current_pool_start + t->size;
+    const char *current_pool_end = (char *) current_pool_start + t->size;
 
     /* Only support coalescing if the new memory is immediately adjacent to the
      * current pool
@@ -967,7 +1001,8 @@ void *tlsf_aalloc(tlsf_t *t, size_t align, size_t size)
 
     ASAN_UNPOISON(block_payload(block), block_size(block));
 
-    char *mem = align_ptr(block_payload(block) + sizeof(tlsf_block_t), align);
+    const char *mem =
+        align_ptr(block_payload(block) + sizeof(tlsf_block_t), align);
     block = block_ltrim_free(t, block, (size_t) (mem - block_payload(block)));
     return block_use(t, block, adjust);
 }
@@ -996,7 +1031,7 @@ size_t tlsf_usable_size(void *ptr)
 {
     if (UNLIKELY(!ptr))
         return 0;
-    tlsf_block_t *block = block_from_payload(ptr);
+    const tlsf_block_t *block = block_from_payload(ptr);
     ASSERT(!block_is_free(block), "block must be allocated");
     return block_size(block);
 }
@@ -1118,9 +1153,7 @@ size_t tlsf_pool_init(tlsf_t *t, void *mem, size_t bytes)
      * sentinel so that free-list insert/remove can write unconditionally.
      */
     memset(t, 0, sizeof(*t));
-    for (uint32_t i = 0; i < FL_COUNT; i++)
-        for (uint32_t j = 0; j < SL_COUNT; j++)
-            t->block[i][j] = &t->block_null;
+    bins_reset(t);
 
     /* Align pool start */
     char *start = align_ptr((char *) mem, ALIGN_SIZE);
@@ -1142,22 +1175,8 @@ size_t tlsf_pool_init(tlsf_t *t, void *mem, size_t bytes)
     t->fixed = true;
     t->arena = start;
 
-    /* Set up the initial free block. The block struct starts at start -
-     * BLOCK_OVERHEAD so that block->header aligns with start. The prev field
-     * sits before the arena and is never accessed for the first block.
-     */
-    tlsf_block_t *block = to_block(start - BLOCK_OVERHEAD);
-    block->header = free_size | BLOCK_BIT_FREE;
-    block_insert(t, block);
-
-    /* Set up sentinel at the end of the free block */
-    tlsf_block_t *sentinel = block_link_next(block);
-    sentinel->header = BLOCK_BIT_PREV_FREE;
-    check_sentinel(sentinel);
-
+    pool_build(t, start, free_size);
     t->size = free_size + 2 * BLOCK_OVERHEAD;
-
-    block_poison_free(block);
 
     return free_size;
 }
@@ -1170,30 +1189,10 @@ void tlsf_pool_reset(tlsf_t *t)
     /* Unpoison the entire pool for ASan. */
     ASAN_UNPOISON(t->arena, t->size);
 
-    /* Clear bitmaps. */
-    t->fl = 0;
-    memset(t->sl, 0, sizeof(t->sl));
+    bins_reset(t);
 
-    /* Reset all bin pointers to sentinel. */
-    for (uint32_t i = 0; i < FL_COUNT; i++)
-        for (uint32_t j = 0; j < SL_COUNT; j++)
-            t->block[i][j] = &t->block_null;
-
-    /* Reconstruct the single free block spanning the entire pool. Same layout
-     * as the second half of tlsf_pool_init().
-     */
-    size_t free_size = t->size - 2 * BLOCK_OVERHEAD;
-
-    tlsf_block_t *block = to_block((char *) t->arena - BLOCK_OVERHEAD);
-    block->header = free_size | BLOCK_BIT_FREE;
-    block_insert(t, block);
-
-    /* Sentinel at the end of the pool. */
-    tlsf_block_t *sentinel = block_link_next(block);
-    sentinel->header = BLOCK_BIT_PREV_FREE;
-    check_sentinel(sentinel);
-
-    block_poison_free(block);
+    /* Reconstruct the single free block spanning the entire pool. */
+    pool_build(t, (char *) t->arena, t->size - 2 * BLOCK_OVERHEAD);
 }
 
 #ifdef TLSF_ENABLE_CHECK
@@ -1342,8 +1341,8 @@ void tlsf_check(tlsf_t *t)
              * that each block maps to its bin, so a block cannot appear in two
              * different bins without failing the fl/sl check first.
              */
-            tlsf_block_t *list_prev = &t->block_null;
-            tlsf_block_t *fast = list_block;
+            const tlsf_block_t *list_prev = &t->block_null;
+            const tlsf_block_t *fast = list_block;
             while (list_block != &t->block_null) {
                 list_free_count++;
 

--- a/src/tlsf.c
+++ b/src/tlsf.c
@@ -1130,12 +1130,12 @@ void tlsf_pool_reset(tlsf_t *t)
 #include <stdio.h>
 #include <stdlib.h>
 #define CHECK(cond, msg)                                          \
-    ({                                                            \
+    do {                                                          \
         if (!(cond)) {                                            \
             fprintf(stderr, "TLSF CHECK: %s - %s\n", msg, #cond); \
             abort();                                              \
         }                                                         \
-    })
+    } while (0)
 
 /**
  * Comprehensive heap consistency check.

--- a/src/tlsf.c
+++ b/src/tlsf.c
@@ -479,16 +479,6 @@ INLINE void mapping(size_t size, uint32_t *fl, uint32_t *sl)
     ASSERT(*sl < SL_COUNT, "wrong second level");
 }
 
-/* Calculate the minimum block size for a given FL/SL bin */
-INLINE size_t mapping_size(uint32_t fl, uint32_t sl)
-{
-    if (fl == 0)
-        return sl * (BLOCK_SIZE_SMALL / SL_COUNT);
-
-    size_t size = (size_t) 1 << (fl + FL_SHIFT - 1);
-    return size + (sl * (size >> SL_SHIFT));
-}
-
 INLINE tlsf_block_t *block_find_suitable(tlsf_t *t, uint32_t *fl, uint32_t *sl)
 {
     ASSERT(*fl < FL_COUNT, "wrong first level");
@@ -936,11 +926,15 @@ INLINE tlsf_block_t *block_find_free(tlsf_t *t, size_t *size)
         ASSERT(block, "no block found");
     }
 
-    /* Update size to match the FL/SL bin that was actually used. This ensures
-     * that when the block is freed, it will be placed in the same bin it was
-     * allocated from.
+    /* *size stays at the rounded request. round_block_size() above already put
+     * it exactly on a bin boundary, which is what issue #4 requires: a freed
+     * block lands in the bin a same-size request will search.
+     *
+     * Do NOT substitute mapping_size(fl, sl) here. block_find_suitable() may
+     * return a block from a LARGER bin than the request maps to, and inflating
+     * the allocation to that bin's minimum hands out the whole block: a fresh 1
+     * MB pool then served two 1 KB allocations instead of ~1000.
      */
-    *size = mapping_size(fl, sl);
     ASSERT(block_size(block) >= *size, "insufficient block size");
     remove_free_block(t, block, fl, sl);
     return block;

--- a/src/tlsf.c
+++ b/src/tlsf.c
@@ -11,6 +11,20 @@
 #include <intrin.h>
 #endif
 
+/* Bit-scan intrinsic selection. Toolchains that are neither GCC-family nor MSVC
+ * (IAR, Green Hills, TI, ARM Compiler 5) fall through to the portable
+ * implementations below, which are fixed-step and therefore still O(1). Define
+ * TLSF_NO_INTRINSICS to force that path; CI uses it to test it.
+ */
+#ifndef TLSF_NO_INTRINSICS
+#if defined(__GNUC__) || defined(__MINGW32__) || defined(__MINGW64__) || \
+    defined(__clang__)
+#define TLSF_BUILTIN_BITSCAN 1
+#elif defined(_MSC_VER)
+#define TLSF_MSVC_BITSCAN 1
+#endif
+#endif
+
 #include "tlsf.h"
 
 #ifndef UNLIKELY
@@ -172,36 +186,79 @@ void *tlsf_resize_default(tlsf_t *t, size_t size)
 INLINE uint32_t bitmap_ffs(uint32_t x)
 {
     ASSERT(x, "no set bit found");
-#if defined(__GNUC__) || defined(__MINGW32__) || defined(__MINGW64__) || \
-    defined(__clang__)
+#if defined(TLSF_BUILTIN_BITSCAN)
     return (uint32_t) __builtin_ctz(x);
-#elif defined(_MSC_VER)
+#elif defined(TLSF_MSVC_BITSCAN)
     unsigned long index;
-    if (_BitScanForward(&index, x)) {
-        return (int) (index);
-    }
-    return 0;
+    return _BitScanForward(&index, x) ? (uint32_t) index : 0;
+#else
+    /* Isolate the lowest set bit, then accumulate its index with five mask
+     * tests. Each mask covers the positions whose index has that bit set.
+     */
+    uint32_t lsb = x & (~x + 1U);
+    uint32_t n = 0;
+    if (lsb & 0xFFFF0000U)
+        n += 16;
+    if (lsb & 0xFF00FF00U)
+        n += 8;
+    if (lsb & 0xF0F0F0F0U)
+        n += 4;
+    if (lsb & 0xCCCCCCCCU)
+        n += 2;
+    if (lsb & 0xAAAAAAAAU)
+        n += 1;
+    return n;
 #endif
 }
 
 INLINE uint32_t log2floor(size_t x)
 {
     ASSERT(x > 0, "log2 of zero");
-#if defined(__GNUC__) || defined(__MINGW32__) || defined(__MINGW64__) || \
-    defined(__clang__)
+#if defined(TLSF_BUILTIN_BITSCAN)
 #if _TLSF_SIZE_WIDTH == 64
     return (uint32_t) (63 - (uint32_t) __builtin_clzll((unsigned long long) x));
 #else
     return (uint32_t) (31 - (uint32_t) __builtin_clzl((unsigned long) x));
 #endif
-#elif defined(_MSC_VER)
-    unsigned long index;
+#elif defined(TLSF_MSVC_BITSCAN)
+    /* Zero-initialized: the intrinsic leaves index untouched when x is 0, and
+     * ASSERT is compiled out in release builds.
+     */
+    unsigned long index = 0;
 #if _TLSF_SIZE_WIDTH == 64
     _BitScanReverse64(&index, (unsigned __int64) x);
 #else
     _BitScanReverse(&index, (unsigned long) x);
 #endif
     return (uint32_t) index;
+#else
+    /* Fixed-step binary search over the word. */
+    uint32_t n = 0;
+#if _TLSF_SIZE_WIDTH == 64
+    if (x >> 32) {
+        x >>= 32;
+        n += 32;
+    }
+#endif
+    if (x >> 16) {
+        x >>= 16;
+        n += 16;
+    }
+    if (x >> 8) {
+        x >>= 8;
+        n += 8;
+    }
+    if (x >> 4) {
+        x >>= 4;
+        n += 4;
+    }
+    if (x >> 2) {
+        x >>= 2;
+        n += 2;
+    }
+    if (x >> 1)
+        n += 1;
+    return n;
 #endif
 }
 

--- a/src/tlsf.c
+++ b/src/tlsf.c
@@ -690,8 +690,8 @@ INLINE void check_sentinel(tlsf_block_t *block)
 
 static bool arena_grow(tlsf_t *t, size_t size)
 {
-    /* Static pools cannot grow. */
-    if (t->arena)
+    /* Fixed pools cannot grow. */
+    if (t->fixed)
         return false;
 
     /* First use of a dynamic pool: point all empty-bin pointers at the sentinel
@@ -717,6 +717,11 @@ static bool arena_grow(tlsf_t *t, size_t size)
     if (!addr)
         return false;
     ASSERT((size_t) addr % ALIGN_SIZE == 0, "wrong heap alignment address");
+
+    /* Cache the base so later reads (tlsf_check, tlsf_get_stats, pool append)
+     * never have to call back into tlsf_resize just to learn the address.
+     */
+    t->arena = addr;
 
     /* Clear stale ASan shadow in the growth region: prior arena_shrink cycles
      * may have left poisoned shadow bytes that were never cleared.
@@ -750,10 +755,10 @@ static size_t arena_append_pool(tlsf_t *t, void *mem, size_t size)
     char *end = (char *) mem + size;
     size_t aligned_size = (size_t) (end - start) & ~(ALIGN_SIZE - 1);
 
-    /* For static pools, the new sentinel must fit within the appended region
+    /* For fixed pools, the new sentinel must fit within the appended region
      * itself, since there is no backend to provide extra bytes.
      */
-    if (t->arena) {
+    if (t->fixed) {
         if (aligned_size <= BLOCK_OVERHEAD)
             return 0;
         aligned_size -= BLOCK_OVERHEAD;
@@ -763,7 +768,7 @@ static size_t arena_append_pool(tlsf_t *t, void *mem, size_t size)
         return 0;
 
     /* Get current pool information */
-    void *current_pool_start = t->arena ? t->arena : tlsf_resize(t, t->size);
+    void *current_pool_start = t->arena;
     if (!current_pool_start)
         return 0;
 
@@ -785,14 +790,15 @@ static size_t arena_append_pool(tlsf_t *t, void *mem, size_t size)
     if (UNLIKELY(new_total_size > (size_t) 1 << FL_MAX))
         return 0;
 
-    /* For dynamic pools, request the backend to extend. For static pools, the
+    /* For dynamic pools, request the backend to extend. For fixed pools, the
      * caller provides adjacent memory directly.
      */
-    if (!t->arena) {
+    if (!t->fixed) {
         void *resized = tlsf_resize(t, new_total_size);
         if (!resized)
             return 0;
         current_pool_start = resized;
+        t->arena = resized;
 
         /* Clear stale ASan shadow in the extension region. */
         ASAN_UNPOISON((char *) resized + old_size, new_total_size - old_size);
@@ -870,8 +876,14 @@ static void arena_shrink(tlsf_t *t, tlsf_block_t *block)
     t->size = t->size - size - BLOCK_OVERHEAD;
     if (t->size == BLOCK_OVERHEAD)
         t->size = 0;
-    tlsf_resize(t, t->size);
-    if (t->size) {
+    void *addr = tlsf_resize(t, t->size);
+    if (!t->size) {
+        /* Pool fully released; the next allocation grows it from scratch. */
+        t->arena = NULL;
+    } else {
+        /* Keep the previous base if the backend declined to shrink. */
+        if (addr)
+            t->arena = addr;
         block->header = 0;
         check_sentinel(block);
     }
@@ -974,7 +986,7 @@ void tlsf_free(tlsf_t *t, void *mem)
 
     block_poison_free(block);
 
-    if (UNLIKELY(!block_size(block_next(block))) && !t->arena)
+    if (UNLIKELY(!block_size(block_next(block))) && !t->fixed)
         arena_shrink(t, block);
     else
         block_insert(t, block);
@@ -1126,7 +1138,8 @@ size_t tlsf_pool_init(tlsf_t *t, void *mem, size_t bytes)
     if (free_size < BLOCK_SIZE_MIN || free_size > BLOCK_SIZE_MAX)
         return 0;
 
-    /* Mark as static (fixed-size) pool */
+    /* Mark as a fixed-size, caller-owned pool */
+    t->fixed = true;
     t->arena = start;
 
     /* Set up the initial free block. The block struct starts at start -
@@ -1151,7 +1164,7 @@ size_t tlsf_pool_init(tlsf_t *t, void *mem, size_t bytes)
 
 void tlsf_pool_reset(tlsf_t *t)
 {
-    if (!t || !t->arena)
+    if (!t || !t->fixed)
         return;
 
     /* Unpoison the entire pool for ASan. */
@@ -1212,7 +1225,7 @@ void tlsf_check(tlsf_t *t)
         return;
 
     /* Get arena start */
-    void *arena_start = t->arena ? t->arena : tlsf_resize(t, t->size);
+    void *arena_start = t->arena;
     CHECK(arena_start, "failed to get arena pointer");
     CHECK((size_t) arena_start % ALIGN_SIZE == 0, "arena not aligned");
 
@@ -1390,10 +1403,6 @@ void tlsf_check(tlsf_t *t)
 /**
  * Collect heap statistics by walking all blocks.
  *
- * Note: This function relies on tlsf_resize(t, t->size) being idempotent
- * (returning the current arena address without reallocation). The platform-
- * specific tlsf_resize implementation must honor this contract.
- *
  * Statistics semantics:
  * - total_free/total_used: Payload bytes (usable by application)
  * - overhead: Metadata bytes (block headers + sentinel)
@@ -1415,14 +1424,11 @@ int tlsf_get_stats(tlsf_t *t, tlsf_stats_t *stats)
     if (!t->size)
         return 0; /* Empty pool */
 
-    /* Get arena start. For static pools, use the stored arena pointer. For
-     * dynamic pools, query via tlsf_resize (which must return the current arena
-     * pointer without reallocation or side effects).
-     *
-     * The first block is at arena_start - BLOCK_OVERHEAD because the
-     * tlsf_block_t structure's prev field precedes the header.
+    /* t->arena is the current base for both fixed and dynamic pools. The first
+     * block sits at arena_start - BLOCK_OVERHEAD because the tlsf_block_t
+     * structure's prev field precedes the header.
      */
-    void *arena_start = t->arena ? t->arena : tlsf_resize(t, t->size);
+    void *arena_start = t->arena;
     if (!arena_start)
         return -1;
 

--- a/src/tlsf_thread.c
+++ b/src/tlsf_thread.c
@@ -43,66 +43,61 @@ static inline int arena_find(const tlsf_thread_t *ts, const void *ptr)
     return -1;
 }
 
+/* Allocate from one arena. align == 0 selects plain tlsf_malloc, which keeps
+ * the malloc and aligned-alloc paths from being two copies of everything.
+ * Caller holds the arena lock.
+ */
+static void *arena_alloc(tlsf_arena_t *a, size_t align, size_t size)
+{
+    return align ? tlsf_aalloc(&a->pool, align, size)
+                 : tlsf_malloc(&a->pool, size);
+}
+
 /* Try to allocate from arenas other than `skip`, using non-blocking try-lock
  * first, then blocking acquire.
  *
  * Returns NULL if all arenas are exhausted.
  */
-static void *arena_fallback_malloc(tlsf_thread_t *ts, int skip, size_t size)
+static void *arena_fallback_alloc(tlsf_thread_t *ts,
+                                  int skip,
+                                  size_t align,
+                                  size_t size)
 {
-    void *ptr;
-
-    /* Phase 1: non-blocking scan */
-    for (int i = 1; i < ts->count; i++) {
-        int idx = (skip + i) % ts->count;
-        if (TLSF_LOCK_TRY(&ts->arenas[idx].lock)) {
-            ptr = tlsf_malloc(&ts->arenas[idx].pool, size);
+    /* Pass 0: skip arenas that are busy. Pass 1: wait for them. */
+    for (int pass = 0; pass < 2; pass++) {
+        for (int i = 1; i < ts->count; i++) {
+            int idx = (skip + i) % ts->count;
+            if (!pass) {
+                if (!TLSF_LOCK_TRY(&ts->arenas[idx].lock))
+                    continue;
+            } else {
+                TLSF_LOCK_ACQUIRE(&ts->arenas[idx].lock);
+            }
+            void *ptr = arena_alloc(&ts->arenas[idx], align, size);
             TLSF_LOCK_RELEASE(&ts->arenas[idx].lock);
             if (ptr)
                 return ptr;
         }
-    }
-
-    /* Phase 2: blocking scan */
-    for (int i = 1; i < ts->count; i++) {
-        int idx = (skip + i) % ts->count;
-        TLSF_LOCK_ACQUIRE(&ts->arenas[idx].lock);
-        ptr = tlsf_malloc(&ts->arenas[idx].pool, size);
-        TLSF_LOCK_RELEASE(&ts->arenas[idx].lock);
-        if (ptr)
-            return ptr;
     }
 
     return NULL;
 }
 
-static void *arena_fallback_aalloc(tlsf_thread_t *ts,
-                                   int skip,
-                                   size_t align,
-                                   size_t size)
+/* Preferred arena first, then everyone else. */
+static void *thread_alloc(tlsf_thread_t *ts, size_t align, size_t size)
 {
-    void *ptr;
+    if (!ts || !ts->count)
+        return NULL;
 
-    for (int i = 1; i < ts->count; i++) {
-        int idx = (skip + i) % ts->count;
-        if (TLSF_LOCK_TRY(&ts->arenas[idx].lock)) {
-            ptr = tlsf_aalloc(&ts->arenas[idx].pool, align, size);
-            TLSF_LOCK_RELEASE(&ts->arenas[idx].lock);
-            if (ptr)
-                return ptr;
-        }
-    }
+    int preferred = arena_select(ts);
 
-    for (int i = 1; i < ts->count; i++) {
-        int idx = (skip + i) % ts->count;
-        TLSF_LOCK_ACQUIRE(&ts->arenas[idx].lock);
-        ptr = tlsf_aalloc(&ts->arenas[idx].pool, align, size);
-        TLSF_LOCK_RELEASE(&ts->arenas[idx].lock);
-        if (ptr)
-            return ptr;
-    }
+    TLSF_LOCK_ACQUIRE(&ts->arenas[preferred].lock);
+    void *ptr = arena_alloc(&ts->arenas[preferred], align, size);
+    TLSF_LOCK_RELEASE(&ts->arenas[preferred].lock);
+    if (ptr)
+        return ptr;
 
-    return NULL;
+    return arena_fallback_alloc(ts, preferred, align, size);
 }
 
 size_t tlsf_thread_init(tlsf_thread_t *ts, void *mem, size_t bytes)
@@ -132,12 +127,21 @@ size_t tlsf_thread_init(tlsf_thread_t *ts, void *mem, size_t bytes)
 
         ts->arenas[i].base = base + (size_t) i * per_arena;
         ts->arenas[i].capacity = chunk;
-        TLSF_LOCK_INIT(&ts->arenas[i].lock);
+
+        /* A failed lock init leaves an unusable mutex behind, so bail out
+         * before any caller can acquire it. Only locks [0, i) exist here.
+         */
+        if (TLSF_LOCK_INIT(&ts->arenas[i].lock) != 0) {
+            for (int j = 0; j < i; j++)
+                TLSF_LOCK_DESTROY(&ts->arenas[j].lock);
+            memset(ts, 0, sizeof(*ts));
+            return 0;
+        }
 
         size_t usable =
             tlsf_pool_init(&ts->arenas[i].pool, ts->arenas[i].base, chunk);
         if (!usable) {
-            /* Cleanup previously initialized arenas. */
+            /* Cleanup previously initialized arenas, including this one. */
             for (int j = 0; j <= i; j++)
                 TLSF_LOCK_DESTROY(&ts->arenas[j].lock);
             memset(ts, 0, sizeof(*ts));
@@ -161,43 +165,23 @@ void tlsf_thread_destroy(tlsf_thread_t *ts)
 
 void *tlsf_thread_malloc(tlsf_thread_t *ts, size_t size)
 {
-    if (!ts->count)
-        return NULL;
-
-    int preferred = arena_select(ts);
-    void *ptr;
-
-    /* Fast path: thread-preferred arena. */
-    TLSF_LOCK_ACQUIRE(&ts->arenas[preferred].lock);
-    ptr = tlsf_malloc(&ts->arenas[preferred].pool, size);
-    TLSF_LOCK_RELEASE(&ts->arenas[preferred].lock);
-    if (ptr)
-        return ptr;
-
-    /* Slow path: try remaining arenas. */
-    return arena_fallback_malloc(ts, preferred, size);
+    return thread_alloc(ts, 0, size);
 }
 
 void *tlsf_thread_aalloc(tlsf_thread_t *ts, size_t align, size_t size)
 {
-    if (!ts->count)
+    /* Reject align == 0 here rather than letting it mean "plain malloc"
+     * internally; tlsf_aalloc() rejects it too.
+     */
+    if (!align)
         return NULL;
 
-    int preferred = arena_select(ts);
-    void *ptr;
-
-    TLSF_LOCK_ACQUIRE(&ts->arenas[preferred].lock);
-    ptr = tlsf_aalloc(&ts->arenas[preferred].pool, align, size);
-    TLSF_LOCK_RELEASE(&ts->arenas[preferred].lock);
-    if (ptr)
-        return ptr;
-
-    return arena_fallback_aalloc(ts, preferred, align, size);
+    return thread_alloc(ts, align, size);
 }
 
 void tlsf_thread_free(tlsf_thread_t *ts, void *ptr)
 {
-    if (!ptr)
+    if (!ts || !ptr)
         return;
 
     int idx = arena_find(ts, ptr);
@@ -211,6 +195,9 @@ void tlsf_thread_free(tlsf_thread_t *ts, void *ptr)
 
 void *tlsf_thread_realloc(tlsf_thread_t *ts, void *ptr, size_t size)
 {
+    if (!ts)
+        return NULL;
+
     if (!ptr)
         return tlsf_thread_malloc(ts, size);
 

--- a/tests/bench.c
+++ b/tests/bench.c
@@ -116,8 +116,8 @@ static void compute_stats(double *samples, size_t n, stats_t *stats)
         stats->median = samples[n / 2];
 
     /* Safe percentile indexing with bounds check */
-    size_t p5_idx = (size_t) (n * 0.05);
-    size_t p95_idx = (size_t) (n * 0.95);
+    size_t p5_idx = (size_t) ((double) n * 0.05);
+    size_t p95_idx = (size_t) ((double) n * 0.95);
     if (p5_idx >= n)
         p5_idx = 0;
     if (p95_idx >= n)
@@ -373,12 +373,11 @@ int main(int argc, char **argv)
         seed = 1; /* xorshift32 requires non-zero state */
     xorshift_state = seed;
 
-    if (!quiet)
-        printf("Random seed: %u (use for reproducibility)\n\n", seed);
-
     /* Warmup phase - stabilize caches, TLB, branch predictors */
-    if (!quiet)
+    if (!quiet) {
+        printf("Random seed: %u (use for reproducibility)\n\n", seed);
         printf("Warming up (%zu iterations)...\n", warmup);
+    }
 
     for (size_t i = 0; i < warmup; i++) {
         run_alloc_benchmark(loops, blk_min, blk_max, blk_array, num_blks,

--- a/tests/pool_limits.h
+++ b/tests/pool_limits.h
@@ -1,0 +1,51 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * tlsf-bsd is freely redistributable under the BSD License. See the file
+ * "LICENSE" for information on usage and redistribution of this file.
+ */
+
+/* Pool sizing limits derived from the build configuration.
+ *
+ * A dynamic arena can never exceed 2^_TLSF_FL_MAX bytes, and tlsf_pool_init()
+ * rejects a static pool whose single initial free block would exceed
+ * BLOCK_SIZE_MAX (2^(_TLSF_FL_MAX - 1)). The default build puts these limits
+ * far above anything the tests ask for, but -DTLSF_MAX_POOL_BITS=N brings them
+ * down sharply. Tests size their pools through the macros here so a reduced
+ * TLSF_MAX_POOL_BITS is actually exercised instead of tripping an assertion.
+ */
+
+#pragma once
+
+#include <stddef.h>
+
+#include "tlsf.h"
+
+/* The suite has been validated down to TLSF_MAX_POOL_BITS=18. Below that,
+ * fixtures in fragmentation_test() and elsewhere still carry sizes derived from
+ * the default configuration and start failing on allocation. The library itself
+ * supports smaller values; only these tests do not. Fail at compile time with
+ * an explanation rather than mid-run on an opaque assertion.
+ */
+#if _TLSF_FL_MAX < 18
+#error \
+    "tests require TLSF_MAX_POOL_BITS >= 18 (more fixtures need parameterizing below that)"
+#endif
+
+/* Largest pool size the current configuration comfortably accepts. The factor
+ * of four below 2^_TLSF_FL_MAX leaves headroom for block headers, the sentinel,
+ * and the second live block that some tests hold.
+ */
+#define TLSF_TEST_POOL_MAX ((size_t) 1 << (_TLSF_FL_MAX - 2))
+
+/* Per-allocation cost: the minimum block payload plus its header. Mirrors
+ * BLOCK_SIZE_MIN + BLOCK_OVERHEAD in src/tlsf.c, which tests cannot see.
+ */
+#define TLSF_TEST_BLOCK_COST \
+    (sizeof(struct tlsf_block) - sizeof(struct tlsf_block *) + sizeof(size_t))
+
+/* Clamp a desired pool size to what this configuration accepts. Usable as an
+ * array bound: both operands are integer constant expressions.
+ */
+#define TLSF_TEST_POOL_CLAMP(want)                          \
+    ((size_t) (want) < TLSF_TEST_POOL_MAX ? (size_t) (want) \
+                                          : TLSF_TEST_POOL_MAX)

--- a/tests/test.c
+++ b/tests/test.c
@@ -864,6 +864,85 @@ static void zero_size_align_test(tlsf_t *t)
     printf(". done\n");
 }
 
+/* Pool utilization: a fixed pool must be able to hand out roughly its whole
+ * capacity, not just the first block.
+ *
+ * Regression guard for block_find_free(). When it inflated the allocation to
+ * mapping_size() of the bin the block was FOUND in, rather than leaving it at
+ * the rounded request, the first malloc from a fresh pool swallowed almost the
+ * entire arena: a 1 MB pool served exactly two 1 KB allocations (0.2%
+ * utilization) before reporting exhaustion.
+ */
+static void pool_utilization_test(void)
+{
+    printf("Pool utilization test: ");
+    fflush(stdout);
+
+    static char pool[TLSF_TEST_POOL_CLAMP(256 * 1024)];
+
+    for (size_t req = 64; req <= 8192; req <<= 1) {
+        tlsf_t t;
+        size_t usable = tlsf_pool_init(&t, pool, sizeof(pool));
+        assert(usable > 0);
+        if (req > usable / 8)
+            break; /* too coarse to say anything useful about this pool */
+
+        size_t handed_out = 0;
+        unsigned n = 0;
+        while (tlsf_malloc(&t, req)) {
+            handed_out += req;
+            n++;
+        }
+        tlsf_check(&t);
+
+        /* Every allocation costs a header and is rounded up to a bin
+         * boundary, so exact capacity is not predictable. Anything below half
+         * the pool means blocks are being inflated, not merely rounded.
+         */
+        assert(n > 1);
+        assert(handed_out > usable / 2);
+        printf(".");
+        fflush(stdout);
+    }
+    printf(" done\n");
+}
+
+/* Issue #4: a freed block must land in the bin that a same-size request will
+ * search, so free-then-reallocate at the same size reuses the same address.
+ * Guards against a future change that searches with the rounded size but
+ * stores the block at the unrounded one. The block under test is sandwiched
+ * between live allocations so it cannot coalesce and mask the result.
+ */
+static void reuse_same_address_test(void)
+{
+    printf("Free/realloc address reuse test: ");
+    fflush(stdout);
+
+    static char pool[TLSF_TEST_POOL_CLAMP(256 * 1024)];
+    unsigned checked = 0;
+
+    for (size_t sz = 24; sz <= 16384; sz = sz + 1 + sz / 8) {
+        tlsf_t t;
+        assert(tlsf_pool_init(&t, pool, sizeof(pool)));
+
+        void *guard_lo = tlsf_malloc(&t, 64);
+        void *p = tlsf_malloc(&t, sz);
+        if (!p)
+            break; /* larger sizes will not fit either */
+        void *guard_hi = tlsf_malloc(&t, 64);
+        assert(guard_lo && guard_hi);
+
+        tlsf_free(&t, p);
+        void *again = tlsf_malloc(&t, sz);
+        assert(again == p);
+        tlsf_check(&t);
+        checked++;
+    }
+
+    assert(checked > 0);
+    printf("%u sizes done\n", checked);
+}
+
 /* Test pool reset: O(1) bulk deallocation for static pools. */
 static void pool_reset_test(void)
 {
@@ -1029,6 +1108,12 @@ int main(void)
 
     /* Run pool reset test */
     pool_reset_test();
+
+    /* Run pool utilization test */
+    pool_utilization_test();
+
+    /* Run free/realloc address reuse test */
+    reuse_same_address_test();
 
     puts("OK!");
     return 0;

--- a/tests/test.c
+++ b/tests/test.c
@@ -23,6 +23,8 @@
 
 #include "tlsf.h"
 
+#include "pool_limits.h"
+
 static size_t PAGE;
 static size_t MAX_PAGES;
 static size_t curr_pages = 0;
@@ -196,9 +198,23 @@ static void random_sizes_test(tlsf_t *t)
 {
     const size_t sizes[] = {16, 32, 64, 128, 256, 512, 1024, 1024 * 1024};
 
+    /* random_test() creates up to 2 * spacelen live allocations, each costing
+     * at least TLSF_TEST_BLOCK_COST bytes, and the arena can never exceed
+     * 2^_TLSF_FL_MAX bytes. The item count dominates the 6 * spacelen payload
+     * bound, so size from that; halve again for fragmentation headroom. Skip
+     * entries a reduced TLSF_MAX_POOL_BITS cannot serve rather than asserting.
+     */
+    const size_t space_cap =
+        ((size_t) 1 << _TLSF_FL_MAX) / (4 * TLSF_TEST_BLOCK_COST);
+
     printf("Random allocation test: ");
     for (unsigned i = 0; i < ARRAY_SIZE(sizes); i++) {
         unsigned n = 1024;
+
+        if (sizes[i] > space_cap) {
+            printf("(skip %zu: pool limit) ", sizes[i]);
+            continue;
+        }
 
         while (n--)
 #if defined(_MSC_VER)
@@ -246,6 +262,15 @@ static void large_size_test(tlsf_t *t)
 #endif
     if (max_test > TLSF_MAX_SIZE)
         max_test = TLSF_MAX_SIZE;
+
+    /* large_alloc() keeps two blocks of this size live at once, and the arena
+     * can never exceed 2^_TLSF_FL_MAX bytes. Leave room for both plus metadata
+     * so the test tracks a reduced TLSF_MAX_POOL_BITS instead of assuming the
+     * default configuration.
+     */
+    size_t pool_cap = TLSF_TEST_POOL_MAX;
+    if (max_test > pool_cap)
+        max_test = pool_cap;
 
     size_t s = 1;
     while (s <= max_test) {
@@ -566,7 +591,7 @@ static void static_pool_test(void)
 
     /* Test 1: Basic init, alloc, free */
     {
-        static char pool[1024 * 1024]; /* 1 MB */
+        static char pool[TLSF_TEST_POOL_CLAMP(1024 * 1024)];
         tlsf_t t;
         size_t usable = tlsf_pool_init(&t, pool, sizeof(pool));
         assert(usable > 0);

--- a/tests/test.c
+++ b/tests/test.c
@@ -907,6 +907,50 @@ static void pool_utilization_test(void)
     printf(" done\n");
 }
 
+/* TLSF_MAX_POOL_BYTES must equal what tlsf_pool_init() actually accepts.
+ *
+ * A _Static_assert cannot establish this. The macro and the internal block
+ * constants are definitionally the same expression, so asserting they are
+ * equal is a tautology that survives any drift in the acceptance logic itself:
+ * a different overhead-word count, a changed alignment round-down, an extra
+ * sentinel. Only calling the function pins the published ceiling to reality.
+ *
+ * The ceiling is 256 GiB in the default configuration, far past what can be
+ * backed with memory, so the boundary is exercised under a reduced
+ * TLSF_MAX_POOL_BITS. CI covers 20 and 24.
+ */
+static void pool_ceiling_test(void)
+{
+    printf("Pool ceiling test: ");
+    fflush(stdout);
+
+    if (TLSF_MAX_POOL_BYTES > (size_t) 64 << 20) {
+        printf(
+            "skipped (ceiling %zu bytes exceeds what we can allocate; "
+            "build with -DTLSF_MAX_POOL_BITS=24 or less to cover it)\n",
+            (size_t) TLSF_MAX_POOL_BYTES);
+        return;
+    }
+
+    /* One extra alignment step so the reject case has memory behind it. */
+    const size_t align = sizeof(void *);
+    char *mem = (char *) malloc(TLSF_MAX_POOL_BYTES + align);
+    assert(mem);
+    assert((size_t) mem % align == 0); /* else adj shifts the boundary */
+
+    tlsf_t t;
+    size_t at = tlsf_pool_init(&t, mem, TLSF_MAX_POOL_BYTES);
+    assert(at > 0); /* the published ceiling must be accepted */
+    tlsf_check(&t);
+
+    size_t over = tlsf_pool_init(&t, mem, TLSF_MAX_POOL_BYTES + align);
+    assert(over == 0); /* and one alignment step past it must not be */
+
+    free(mem);
+    printf("%zu accepted, +%zu rejected\n", (size_t) TLSF_MAX_POOL_BYTES,
+           align);
+}
+
 /* Issue #4: a freed block must land in the bin that a same-size request will
  * search, so free-then-reallocate at the same size reuses the same address.
  * Guards against a future change that searches with the rounded size but
@@ -1114,6 +1158,9 @@ int main(void)
 
     /* Run free/realloc address reuse test */
     reuse_same_address_test();
+
+    /* Run pool ceiling test */
+    pool_ceiling_test();
 
     puts("OK!");
     return 0;

--- a/tests/test_thread.c
+++ b/tests/test_thread.c
@@ -24,9 +24,11 @@
 
 #include "tlsf_thread.h"
 
+#include "pool_limits.h"
+
 /* Test parameters (tuned for < 2s on modern hardware) */
 
-#define POOL_SIZE (4 * 1024 * 1024) /* 4 MB static pool */
+#define POOL_SIZE TLSF_TEST_POOL_CLAMP(4 * 1024 * 1024) /* 4 MB static pool */
 #define NUM_THREADS 8
 #define OPS_PER_THREAD 50000
 #define MAX_ALLOCS 128

--- a/tests/wcet.c
+++ b/tests/wcet.c
@@ -307,17 +307,10 @@ static void measure_malloc_best(char *pool,
 
 /* Allocate three adjacent blocks of the requested size from a static pool.
  *
- * TLSF's block_find_free updates the request size to mapping_size(found_bin),
- * which can be far larger than the original request when the pool has a single
- * huge free block (e.g., requesting 1024 from a 4MB pool allocates ~4MB due to
- * bin-minimum inflation). This prevents multiple allocations from a fresh pool.
- *
- * Workaround: allocate each block at the inflated size, then immediately
- * realloc down to the target size. Realloc's trim path (block_rtrim_used)
- * splits the oversized block, returning the excess to the free list. The excess
- * merges with any adjacent free block, making space for the next allocation.
- * After three malloc+realloc cycles, we have three adjacent blocks of the
- * correct size.
+ * This used to need a malloc-then-realloc-down dance: block_find_free()
+ * inflated each request to the minimum size of the bin the block was found in,
+ * so the first allocation from a fresh pool swallowed nearly the whole arena.
+ * That inflation is gone, and plain malloc now returns a correctly sized block.
  */
 static void alloc_three_blocks(tlsf_t *t,
                                size_t alloc_size,
@@ -326,19 +319,9 @@ static void alloc_three_blocks(tlsf_t *t,
                                void **c)
 {
     *a = tlsf_malloc(t, alloc_size);
-    assert(*a);
-    *a = tlsf_realloc(t, *a, alloc_size);
-    assert(*a);
-
     *b = tlsf_malloc(t, alloc_size);
-    assert(*b);
-    *b = tlsf_realloc(t, *b, alloc_size);
-    assert(*b);
-
     *c = tlsf_malloc(t, alloc_size);
-    assert(*c);
-    *c = tlsf_realloc(t, *c, alloc_size);
-    assert(*c);
+    assert(*a && *b && *c);
 }
 
 /* free worst case: Block sandwiched between two free neighbors.

--- a/tests/wcet.c
+++ b/tests/wcet.c
@@ -536,6 +536,25 @@ int main(int argc, char **argv)
         return 1;
     }
 
+    /* -p bypasses DEFAULT_POOL_SIZE's clamp, and a build with a reduced
+     * TLSF_MAX_POOL_BITS caps how large a pool tlsf_pool_init() will accept.
+     * Probe once here so an oversized -p reports the reason, instead of
+     * aborting on an opaque assertion inside a measurement loop.
+     */
+    {
+        tlsf_t probe;
+        if (!tlsf_pool_init(&probe, pool, pool_size)) {
+            fprintf(stderr,
+                    "Error: tlsf_pool_init rejected a %zu byte pool; this "
+                    "build accepts at most %zu bytes "
+                    "(TLSF_MAX_POOL_BYTES, set by TLSF_MAX_POOL_BITS=%d)\n",
+                    pool_size, (size_t) TLSF_MAX_POOL_BYTES, _TLSF_FL_MAX);
+            free(pool);
+            free(samples);
+            return 1;
+        }
+    }
+
     if (cold_cache) {
         thrash_buf = (char *) malloc(THRASH_SIZE);
         if (!thrash_buf) {

--- a/tests/wcet.c
+++ b/tests/wcet.c
@@ -42,6 +42,8 @@
 
 #include "tlsf.h"
 
+#include "pool_limits.h"
+
 /* Timing primitives */
 
 typedef uint64_t tick_t;
@@ -494,7 +496,7 @@ static size_t parse_size_arg(const char *arg, const char *name)
 
 /* Main */
 
-#define DEFAULT_POOL_SIZE ((size_t) 4 << 20) /* 4 MB */
+#define DEFAULT_POOL_SIZE TLSF_TEST_POOL_CLAMP((size_t) 4 << 20) /* 4 MB */
 
 int main(int argc, char **argv)
 {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes Windows MSVC CI and restores correct fixed‑pool utilization. Old behavior inflated allocations to the minimum of the bin a block was found in and overloaded “fixed pool” with the arena base; new behavior keeps the rounded request size, adds a `fixed` flag while `arena` always caches the current base, removes any implicit `tlsf_resize` idempotence requirement, adds portable bit‑scan fallbacks, and publishes `TLSF_MAX_POOL_BYTES` for callers sizing static pools.

- Hardened thread wrapper: unified NULL‑guarding across APIs, normalized `TLSF_LOCK_INIT` to return 0 on success, and fail‑fast `tlsf_thread_init`; allocation paths share a single fallback routine and prefer the calling thread’s arena.

**CI/build + tests**
- Windows: compile with `/std:c11`, replace GNU‑only `CHECK` with `do { … } while (0)`, and raise the job timeout to 10 minutes.
- Matrix: add ThreadSanitizer, a 32‑bit job, and config variants (`TLSF_NO_INTRINSICS`, `TLSF_MAX_POOL_BITS`, `TLSF_SPLIT_THRESHOLD`).
- Tests: parameterize pool sizes via `tests/pool_limits.h`; add utilization and same‑address reuse regressions and a pool‑ceiling test that exercises `TLSF_MAX_POOL_BYTES`.

**Migration**
- Build as C11 and compile every translation unit with identical configuration macros (e.g., `TLSF_MAX_POOL_BITS`, `TLSF_ENABLE_CHECK`).
- Custom locks: make `TLSF_LOCK_INIT` return 0 on success; `tlsf_thread_init` aborts on failure.
- Size fixed pools against `TLSF_MAX_POOL_BYTES`. The bundled tests require `TLSF_MAX_POOL_BITS >= 18`.

<sup>Written for commit 259e8f5598f02e40ad7699cebda10834fea38fd7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/tlsf-bsd/pull/24?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

