### PR TITLE
static assert for old compilers

### DIFF
--- a/include/tlsf.h
+++ b/include/tlsf.h
@@ -111,6 +111,19 @@ extern "C" {
 #define TLSF_INIT_STATIC ((tlsf_t) {.size = 0})
 #endif
 
+#ifndef TLSF_STATIC_ASSERT
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)
+#define TLSF_STATIC_ASSERT(cond, msg) _Static_assert(cond, msg)
+#elif defined(__GNUC__) && ((__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6))
+#define TLSF_STATIC_ASSERT(cond, msg) _Static_assert(cond, msg)
+#else
+#define TLSF_SASSERT_GLUE(a, b) a ## b
+#define TLSF_SASSERT_JOIN(a, b) TLSF_SASSERT_GLUE(a, b)
+#define TLSF_STATIC_ASSERT(cond, msg) \
+        typedef char TLSF_SASSERT_JOIN(STATIC_ASSERT_FAILED_AT_LINE_, __LINE__)[(cond) ? 1 : -1]
+#endif
+#endif
+
 /* Block header structure.
  *
  * prev: Pointer to the previous physical block. Only valid when the

--- a/include/tlsf_thread.h
+++ b/include/tlsf_thread.h
@@ -192,7 +192,7 @@ extern "C" {
 #define TLSF_ARENA_COUNT 4
 #endif
 
-_Static_assert(TLSF_ARENA_COUNT >= 1, "TLSF_ARENA_COUNT must be >= 1");
+TLSF_STATIC_ASSERT(TLSF_ARENA_COUNT >= 1, "TLSF_ARENA_COUNT must be >= 1");
 
 /* Align each arena to a cache line to prevent false sharing between arenas that
  * would otherwise sit on the same line. 64 bytes is the common L1 cache line
@@ -202,7 +202,7 @@ _Static_assert(TLSF_ARENA_COUNT >= 1, "TLSF_ARENA_COUNT must be >= 1");
 #define TLSF_CACHELINE_SIZE 64
 #endif
 
-_Static_assert((TLSF_CACHELINE_SIZE & (TLSF_CACHELINE_SIZE - 1)) == 0,
+TLSF_STATIC_ASSERT((TLSF_CACHELINE_SIZE & (TLSF_CACHELINE_SIZE - 1)) == 0,
                "TLSF_CACHELINE_SIZE must be a power of two");
 
 TLSF_MSVC_ALIGN(TLSF_CACHELINE_SIZE) typedef struct {

--- a/src/tlsf.c
+++ b/src/tlsf.c
@@ -139,25 +139,25 @@
 
 typedef struct tlsf_block tlsf_block_t;
 
-_Static_assert(sizeof(size_t) == 4 || sizeof(size_t) == 8,
+TLSF_STATIC_ASSERT(sizeof(size_t) == 4 || sizeof(size_t) == 8,
                "size_t must be 32 or 64 bit");
-_Static_assert(sizeof(size_t) == sizeof(void *),
+TLSF_STATIC_ASSERT(sizeof(size_t) == sizeof(void *),
                "size_t must equal pointer size");
-_Static_assert(ALIGN_SIZE == BLOCK_SIZE_SMALL / SL_COUNT,
+TLSF_STATIC_ASSERT(ALIGN_SIZE == BLOCK_SIZE_SMALL / SL_COUNT,
                "sizes are not properly set");
-_Static_assert(BLOCK_SIZE_MIN < BLOCK_SIZE_SMALL,
+TLSF_STATIC_ASSERT(BLOCK_SIZE_MIN < BLOCK_SIZE_SMALL,
                "min allocation size is wrong");
-_Static_assert(BLOCK_SIZE_MAX == TLSF_MAX_SIZE + BLOCK_OVERHEAD,
+TLSF_STATIC_ASSERT(BLOCK_SIZE_MAX == TLSF_MAX_SIZE + BLOCK_OVERHEAD,
                "max allocation size is wrong");
-_Static_assert(FL_COUNT <= 32, "index too large");
-_Static_assert(SL_COUNT <= 32, "index too large");
-_Static_assert(FL_COUNT == _TLSF_FL_COUNT, "invalid level configuration");
-_Static_assert(SL_COUNT == _TLSF_SL_COUNT, "invalid level configuration");
-_Static_assert(TLSF_SPLIT_THRESHOLD >= BLOCK_SIZE_MIN,
+TLSF_STATIC_ASSERT(FL_COUNT <= 32, "index too large");
+TLSF_STATIC_ASSERT(SL_COUNT <= 32, "index too large");
+TLSF_STATIC_ASSERT(FL_COUNT == _TLSF_FL_COUNT, "invalid level configuration");
+TLSF_STATIC_ASSERT(SL_COUNT == _TLSF_SL_COUNT, "invalid level configuration");
+TLSF_STATIC_ASSERT(TLSF_SPLIT_THRESHOLD >= BLOCK_SIZE_MIN,
                "split threshold must be at least minimum block size");
-_Static_assert(_TLSF_FL_COUNT >= 1,
+TLSF_STATIC_ASSERT(_TLSF_FL_COUNT >= 1,
                "TLSF_MAX_POOL_BITS too small for this architecture");
-_Static_assert(FL_MAX < _TLSF_SIZE_WIDTH,
+TLSF_STATIC_ASSERT(FL_MAX < _TLSF_SIZE_WIDTH,
                "TLSF_MAX_POOL_BITS must be less than pointer width");
 
 /* Default (weak) implementation of tlsf_resize. Users of tlsf_pool_init() need


### PR DESCRIPTION
There is a way to add static assert for compilers older than C11 and GCC 4.6. Unfortunately there is no way to get the same message as in _Static_assert. On old compilers the message in error case will be like this : total negative subscript   size of array must not exceed 0x7fffffff bytes(this is on MSVC). I.e. proposed macro is not full imitation of _Static_assert. It only stops compilation in error case.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Provides compile‑time assertions on pre‑C11/older GCC by introducing TLSF_STATIC_ASSERT and replacing direct uses of _Static_assert. On modern compilers it maps to _Static_assert; on legacy compilers it uses a typedef trick that stops compilation but may emit a generic error message.

- No runtime, API, or ABI changes; only build‑time behavior changes.
- Review on at least one pre‑C11 compiler (e.g., older MSVC/GCC) to confirm expected generic diagnostics.
- Confirm replacements in tlsf_thread.h and tlsf.c compile across supported toolchains.

<sup>Written for commit 87ec86a0eabdf9d4466fda79db635cf35391f3a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/tlsf-bsd/pull/25?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

