### PR TITLE
improvement for static assert

### DIFF
--- a/include/tlsf.h
+++ b/include/tlsf.h
@@ -114,7 +114,12 @@ extern "C" {
 #ifndef TLSF_STATIC_ASSERT
 #if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)
 #define TLSF_STATIC_ASSERT(cond, msg) _Static_assert(cond, msg)
-#elif defined(__GNUC__) && ((__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6))
+#elif defined(__clang__)
+#if __has_extension(c_static_assert) || __has_feature(c_static_assert)
+#define TLSF_STATIC_ASSERT(cond, msg) _Static_assert(cond, msg)
+#endif
+#elif defined(__GNUC__) && ((__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)) && \
+    !defined(__STRICT_ANSI__)
 #define TLSF_STATIC_ASSERT(cond, msg) _Static_assert(cond, msg)
 #else
 #define TLSF_SASSERT_GLUE(a, b) a ## b


### PR DESCRIPTION
Added some improvement for static assert. Added clang detection(cause it also has _Static_assert before C11) and detection that GNUC is not in strict mode(cause in strict mode there is no _Static_assert before C11).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves TLSF_STATIC_ASSERT detection for pre-C11 compilers to prevent build failures and enable static asserts on Clang. Previously we enabled _Static_assert for GCC ≥ 4.6 even in strict ANSI and missed Clang; now we add Clang feature checks and guard GCC with non-strict mode.

- Clang: define TLSF_STATIC_ASSERT when c_static_assert is available via __has_extension/__has_feature.
- GCC: define TLSF_STATIC_ASSERT only for GCC ≥ 4.6 when not in __STRICT_ANSI__.
- C11 compilers remain unchanged; others continue to use the fallback.

<sup>Written for commit 3911b2fb9285b08c35cff14da7fe9e04e2ba0100. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/tlsf-bsd/pull/26?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

