### PR TITLE
adding SRWLock support

### DIFF
--- a/include/tlsf_thread.h
+++ b/include/tlsf_thread.h
@@ -104,6 +104,18 @@ extern "C" {
 #define WIN32_LEAN_AND_MEAN
 #endif
 #include <windows.h>
+#if defined(__clang__) && (__clang_major__ >= 10)
+#define TLSF_THREAD_WIN_SRWLOCK
+#elif defined(_MSC_VER) && (_MSC_VER >= 1700)
+#define TLSF_THREAD_WIN_SRWLOCK
+#elif defined(__GNUC__) && (__GNUC__ >= 8) && (defined(__MINGW32__) || \
+    defined(__MINGW64__))
+#define TLSF_THREAD_WIN_SRWLOCK
+#elif defined(_WIN32_WINNT) && (_WIN32_WINNT >= 0x0600)
+#define TLSF_THREAD_WIN_SRWLOCK
+#else
+#define TLSF_THREAD_WIN_CRSECTION
+#endif
 #endif
 
 #if defined(USE_C11_THREADS)
@@ -114,7 +126,15 @@ extern "C" {
 #define TLSF_LOCK_ACQUIRE(l) mtx_lock((l))
 #define TLSF_LOCK_RELEASE(l) mtx_unlock((l))
 #define TLSF_LOCK_TRY(l) (mtx_trylock((l)) == thrd_success)
-#elif defined(TLSF_THREAD_WIN)
+#elif defined(TLSF_THREAD_WIN_SRWLOCK)
+#define TLSF_LOCK_T SRWLOCK
+#define TLSF_LOCK_INIT(l) (InitializeSRWLock((l)), 0)
+/* SRWLOCK is just a pointer - no need to destroy it */
+#define TLSF_LOCK_DESTROY(l)
+#define TLSF_LOCK_ACQUIRE(l) AcquireSRWLockExclusive((l))
+#define TLSF_LOCK_RELEASE(l) ReleaseSRWLockExclusive((l))
+#define TLSF_LOCK_TRY(l) (TryAcquireSRWLockExclusive((l)) != 0)
+#elif defined(TLSF_THREAD_WIN_CRSECTION)
 #define TLSF_LOCK_T CRITICAL_SECTION
 #define TLSF_LOCK_INIT(l) (InitializeCriticalSection((l)), 0)
 #define TLSF_LOCK_DESTROY(l) DeleteCriticalSection((l))

--- a/include/tlsf_thread.h
+++ b/include/tlsf_thread.h
@@ -110,8 +110,8 @@ extern "C" {
 #define TLSF_THREAD_WIN_SRWLOCK
 #elif defined(_MSC_VER) && (_MSC_VER >= 1700)
 #define TLSF_THREAD_WIN_SRWLOCK
-#elif defined(__GNUC__) && (__GNUC__ >= 8) && (defined(__MINGW32__) || \
-    defined(__MINGW64__))
+#elif defined(__GNUC__) && (__GNUC__ >= 8) && \
+    (defined(__MINGW32__) || defined(__MINGW64__))
 #define TLSF_THREAD_WIN_SRWLOCK
 #elif
 #define TLSF_THREAD_WIN_CRSECTION

--- a/include/tlsf_thread.h
+++ b/include/tlsf_thread.h
@@ -104,16 +104,16 @@ extern "C" {
 #define WIN32_LEAN_AND_MEAN
 #endif
 #include <windows.h>
-#if defined(__clang__) && (__clang_major__ >= 10)
+#if defined(_WIN32_WINNT) && (_WIN32_WINNT >= 0x0600)
+#define TLSF_THREAD_WIN_SRWLOCK
+#elif defined(__clang__) && (__clang_major__ >= 10)
 #define TLSF_THREAD_WIN_SRWLOCK
 #elif defined(_MSC_VER) && (_MSC_VER >= 1700)
 #define TLSF_THREAD_WIN_SRWLOCK
 #elif defined(__GNUC__) && (__GNUC__ >= 8) && (defined(__MINGW32__) || \
     defined(__MINGW64__))
 #define TLSF_THREAD_WIN_SRWLOCK
-#elif defined(_WIN32_WINNT) && (_WIN32_WINNT >= 0x0600)
-#define TLSF_THREAD_WIN_SRWLOCK
-#else
+#elif
 #define TLSF_THREAD_WIN_CRSECTION
 #endif
 #endif


### PR DESCRIPTION
This PR adds support for SRWLock. SRWLock is full analogue of pthread_mutex_init((l), NULL) cause in this mode there is no recursive. SRWLock is more lightweight and faster. But there is no SRWLock before Windows Vista. Cause it's need to use SRWLock with detecting support of it. It is done with detecting version of compilers thar drops WindowsXP support or corresponding WinNT version.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Uses `SRWLOCK` for locking on supported Windows toolchains and falls back to `CRITICAL_SECTION`. This reduces lock overhead and changes Windows lock semantics from recursive to non-recursive when `SRWLOCK` is used.

- Review and rollout
  - Gate `SRWLOCK` by `_WIN32_WINNT >= 0x0600`; otherwise enable for Clang >= 10, MSVC >= 1700, or GCC >= 8 on MinGW; else use `CRITICAL_SECTION`.
  - Keep public lock macros (`TLSF_LOCK_T`, `TLSF_LOCK_INIT`, `TLSF_LOCK_DESTROY`, `TLSF_LOCK_ACQUIRE`, `TLSF_LOCK_RELEASE`, `TLSF_LOCK_TRY`) unchanged; add internal `TLSF_THREAD_WIN_SRWLOCK` and `TLSF_THREAD_WIN_CRSECTION`.
  - With `SRWLOCK`, `TLSF_LOCK_DESTROY` is a no-op and `TLSF_LOCK_TRY` uses `TryAcquireSRWLockExclusive`. C11 and non-Windows paths unchanged.
  - Migration: if you relied on recursive Windows locks, remove that assumption or force `CRITICAL_SECTION` by targeting `_WIN32_WINNT < 0x0600`.
  - Formatting: adjust preprocessor formatting for Clang; no behavior change.

<sup>Written for commit 7aaf97dc6fbde9adb30b3f515ba68bac25567eff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/tlsf-bsd/pull/28?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

