### PR TITLE
Reject stray operands in benchmark/WCET harnesses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,14 +168,14 @@ jobs:
           cl.exe /Iinclude /O2 /W3 /std:c11 /DTLSF_ENABLE_ASSERT /DTLSF_ENABLE_CHECK src\tlsf.c tests\bench.c /Fe:bench_tlsf.exe /link Psapi.lib
       - name: Run Benchmark TLSF
         run: |
-          .\bench_tlsf.exe
+          .\bench_tlsf.exe -l 10000 -i 3 -w 1
       - name: Compile WCET TLSF with MSVC
         run: |
           cl.exe /Iinclude /O2 /W3 /std:c11 /DTLSF_ENABLE_ASSERT /DTLSF_ENABLE_CHECK src\tlsf.c tests\wcet.c /Fe:wcet_tlsf.exe
-      - name: Run Benchmark TLSF
+      - name: Run WCET TLSF
         run: |
-          .\wcet_tlsf.exe      
-  
+          .\wcet_tlsf.exe -i 100 -w 10
+
   wcet:
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 10

--- a/tests/bench.c
+++ b/tests/bench.c
@@ -14,6 +14,7 @@
 
 #include <assert.h>
 #include <errno.h>
+#include <inttypes.h>
 #include <math.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -57,8 +58,8 @@ static inline uint32_t xorshift32(void)
     return x;
 }
 
-/* Maximum memory consumption in bytes in usage_bytes*/
-int get_systemmem_usage(uint64_t *usage_kbytes)
+/* Peak resident set size in kilobytes. Returns 0 on success, -1 on failure. */
+static int get_systemmem_usage(uint64_t *usage_kbytes)
 {
     if (!usage_kbytes)
         return -1;
@@ -71,11 +72,10 @@ int get_systemmem_usage(uint64_t *usage_kbytes)
     if (GetProcessMemoryInfo(hProcess, &pmc, sizeof(pmc))) {
         /* PeakWorkingSetSize is ru_maxrss analogue in bytes */
         *usage_kbytes = (uint64_t) pmc.PeakWorkingSetSize / 1024ULL;
-    } else {
-        *usage_kbytes = 0;
+        return 0;
     }
 
-    return 0;
+    return -1;
 #else
     struct rusage usage_info;
     if (getrusage(RUSAGE_SELF, &usage_info) != 0) {
@@ -117,21 +117,25 @@ static inline uint64_t get_time_ns(void)
 #endif
 }
 #elif defined(_WIN32) || defined(WIN32) || defined(__WIN32__) || defined(_WIN64)
+static uint64_t qpc_frequency;
+
 static inline uint64_t get_time_ns(void)
 {
+    if (!qpc_frequency) {
+        LARGE_INTEGER frequency;
+        QueryPerformanceFrequency(&frequency);
+        qpc_frequency = (uint64_t) frequency.QuadPart;
+    }
+
     LARGE_INTEGER count;
-    LARGE_INTEGER frequency;
-
     QueryPerformanceCounter(&count);
-    QueryPerformanceFrequency(&frequency);
 
-    uint64_t seconds = (uint64_t) (count.QuadPart / frequency.QuadPart);
-    uint64_t remainder = (uint64_t) (count.QuadPart % frequency.QuadPart);
+    uint64_t ticks = (uint64_t) count.QuadPart;
+    uint64_t seconds = ticks / qpc_frequency;
+    uint64_t remainder = ticks % qpc_frequency;
 
-    uint64_t nanoseconds =
-        (remainder * 1000000000ULL) / (uint64_t) frequency.QuadPart;
-
-    return (seconds * 1000000000ULL) + nanoseconds;
+    return (seconds * 1000000000ULL) +
+           (remainder * 1000000000ULL) / qpc_frequency;
 }
 #else
 static inline uint64_t get_time_ns(void)
@@ -391,6 +395,16 @@ int main(int argc, char **argv)
         }
     }
 
+    /* No positional arguments are accepted. Without this, tlsf_getopt() stops
+     * at the first non-option and every flag after it is silently dropped, so
+     * "bench 64 -l 100000" would quietly measure the defaults instead.
+     */
+    if (state.counter < argc) {
+        fprintf(stderr, "%s: unexpected argument -- '%s'\n", argv[0],
+                argv[state.counter]);
+        usage(argv[0]);
+    }
+
     /* Validate parameters */
     if (iterations == 0) {
         fprintf(stderr, "Error: iterations (-i) must be > 0\n");
@@ -481,9 +495,8 @@ int main(int argc, char **argv)
     compute_stats(samples, iterations, &stats);
 
     /* Get memory usage */
-    uint64_t max_usage_kbytes;
-    int err = get_systemmem_usage(&max_usage_kbytes);
-    assert(err == 0);
+    uint64_t max_usage_kbytes = 0;
+    bool have_rss = get_systemmem_usage(&max_usage_kbytes) == 0;
 
     /* Report results */
     if (quiet) {
@@ -516,7 +529,10 @@ int main(int argc, char **argv)
         printf("  %.0f ops/sec\n", (double) loops / stats.median);
 
         printf("\nMemory:\n");
-        printf("  Peak RSS: %ld KB\n", max_usage_kbytes);
+        if (have_rss)
+            printf("  Peak RSS: %" PRIu64 " KB\n", max_usage_kbytes);
+        else
+            printf("  Peak RSS: unavailable\n");
         printf("  Pool size: %.1f MB\n", (double) max_size / (1024.0 * 1024.0));
 
         printf("\nVariability:\n");

--- a/tests/tlsf_getopt.h
+++ b/tests/tlsf_getopt.h
@@ -24,6 +24,12 @@ typedef struct {
     int num_options;
     char *optarg;
     int counter;
+
+    /* Offset of the next option character inside argv[counter]. Zero means
+     * "start a fresh element"; a non-zero value means a clustered element such
+     * as "-cq" is still being consumed. Callers leave this zero-initialized.
+     */
+    int char_pos;
 } tlsf_getop_state;
 
 static inline tlsf_command_option *tlsf_scan_options(tlsf_getop_state *state,
@@ -37,43 +43,64 @@ static inline tlsf_command_option *tlsf_scan_options(tlsf_getop_state *state,
     return NULL;
 }
 
-int tlsf_getopt(tlsf_getop_state *state)
+/* Returns the option character, '?' on a malformed option, or -1 once the
+ * option list is exhausted. Mirrors getopt(3) closely enough for the test
+ * harnesses: clustered flags ("-cq") and attached arguments ("-s64") both work,
+ * and "--" terminates option processing.
+ */
+static inline int tlsf_getopt(tlsf_getop_state *state)
 {
-    if (!state || state->argc <= 1 || state->num_options == 0 || !state->argv)
+    if (!state || !state->argv || state->argc <= 1 || state->num_options == 0)
         return -1;
     if (state->counter >= state->argc)
         return -1;
 
     state->optarg = NULL;
 
-    char *current_arg = state->argv[state->counter];
+    char *arg = state->argv[state->counter];
 
-    if (current_arg[0] != '-' || current_arg[1] == '\0') {
+    /* A bare "-" or a non-option element ends the scan. */
+    if (arg[0] != '-' || arg[1] == '\0')
+        return -1;
+    /* "--" ends the scan and is consumed. */
+    if (arg[1] == '-' && arg[2] == '\0') {
+        state->counter++;
         return -1;
     }
 
-    char c_option = current_arg[1];
+    if (state->char_pos == 0)
+        state->char_pos = 1;
+
+    char c_option = arg[state->char_pos++];
     tlsf_command_option *option = tlsf_scan_options(state, c_option);
 
-    if (option == NULL) {
+    /* Consumed the last character of this element, so move to the next one. */
+    if (arg[state->char_pos] == '\0') {
+        state->counter++;
+        state->char_pos = 0;
+    }
+
+    if (!option) {
         fprintf(stderr, "%s: unknown option -- '%c'\n", state->argv[0],
                 c_option);
-        state->counter++;
         return '?';
     }
 
-    if (option->is_have_param) {
-        if (state->counter + 1 < state->argc) {
-            state->optarg = state->argv[state->counter + 1];
-            state->counter += 2;
-        } else {
-            fprintf(stderr, "%s: option requires an argument -- '%c'\n",
-                    state->argv[0], c_option);
-            state->counter++;
-            return '?';
-        }
-    } else {
+    if (!option->is_have_param)
+        return c_option;
+
+    if (state->char_pos != 0) {
+        /* Attached argument: the rest of this element, as in "-s64". */
+        state->optarg = arg + state->char_pos;
         state->counter++;
+        state->char_pos = 0;
+    } else if (state->counter < state->argc) {
+        /* Separate argument: the following element, as in "-s 64". */
+        state->optarg = state->argv[state->counter++];
+    } else {
+        fprintf(stderr, "%s: option requires an argument -- '%c'\n",
+                state->argv[0], c_option);
+        return '?';
     }
 
     return c_option;

--- a/tests/wcet.c
+++ b/tests/wcet.c
@@ -124,21 +124,32 @@ static inline tick_t read_tick(void)
 #elif defined(_WIN32) || defined(WIN32) || defined(__WIN32__) || defined(_WIN64)
 #define TICK_UNIT "ns"
 
+/* QPC frequency is fixed at boot, so cache it. Re-reading it on every timestamp
+ * would land inside the measured interval and inflate every sample.
+ *
+ * QPC typically ticks at 10 MHz, i.e. 100 ns granularity, which is coarser than
+ * a single malloc or free. Individual samples therefore quantize to 0 or 100
+ * ns; only aggregate percentiles over many iterations carry meaning here.
+ */
+static uint64_t qpc_frequency;
+
 static inline tick_t read_tick(void)
 {
+    if (!qpc_frequency) {
+        LARGE_INTEGER frequency;
+        QueryPerformanceFrequency(&frequency);
+        qpc_frequency = (uint64_t) frequency.QuadPart;
+    }
+
     LARGE_INTEGER count;
-    LARGE_INTEGER frequency;
-
     QueryPerformanceCounter(&count);
-    QueryPerformanceFrequency(&frequency);
 
-    uint64_t seconds = (uint64_t) (count.QuadPart / frequency.QuadPart);
-    uint64_t remainder = (uint64_t) (count.QuadPart % frequency.QuadPart);
+    uint64_t ticks = (uint64_t) count.QuadPart;
+    uint64_t seconds = ticks / qpc_frequency;
+    uint64_t remainder = ticks % qpc_frequency;
 
-    uint64_t nanoseconds =
-        (remainder * 1000000000ULL) / (uint64_t) frequency.QuadPart;
-
-    return (tick_t) ((seconds * 1000000000ULL) + nanoseconds);
+    return (tick_t) ((seconds * 1000000000ULL) +
+                     (remainder * 1000000000ULL) / qpc_frequency);
 }
 #else
 #define TICK_UNIT "ns"
@@ -565,6 +576,15 @@ int main(int argc, char **argv)
         default:
             usage(argv[0]);
         }
+    }
+
+    /* No positional arguments are accepted. Without this, tlsf_getopt() stops
+     * at the first non-option and every flag after it is silently dropped.
+     */
+    if (state.counter < argc) {
+        fprintf(stderr, "%s: unexpected argument -- '%s'\n", argv[0],
+                argv[state.counter]);
+        usage(argv[0]);
     }
 
     if (!iterations) {


### PR DESCRIPTION
tlsf_getopt() stops at the first non-option element, and neither main() looked at what was left behind, so every flag after an operand was silently discarded. "bench 64 -l 100000" measured the default one million loops at the default 512-byte block size and printed the numbers as though the flags had applied. A benchmark that reports confidently wrong figures is worse than one that fails, because the figures get quoted. Report the leftover element and exit through usage(); neither program documents a positional argument, and every invocation in the Makefile and CI passes flags only.

Extend the parser to the getopt(3) forms the glibc-based code accepted before it was replaced: clustered flags ("-cq"), attached arguments ("-s64"), a cluster ending in a parameterized option ("-cs64" and "-cs 64"), and "--" as a terminator. Tracking the offset within the current element in char_pos is what lets a partially consumed cluster survive across calls. Advance past an exhausted element before the unknown-option branch, so "-x" moves on while a mid-cluster "-xc" still resumes at 'c'. Make tlsf_getopt() static inline: a plain function definition in a header is a multiple-definition hazard as soon as two translation units include it.

Query the performance counter frequency once and cache it rather than calling QueryPerformanceFrequency() on every timestamp, and derive the nanosecond conversion from the cached value.

Stop asserting that the peak resident set query succeeds. It is best-effort, and a measurement harness should print what it has instead of aborting when the platform declines to answer.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject stray operands in the benchmark and WCET harnesses to prevent silently ignored flags. Previously, any option after a non-option was dropped; now the programs report the unexpected argument and exit through usage.

- Enforce no positional arguments in `tests/bench.c` and `tests/wcet.c`; when an extra argv element remains, print it and exit.
- Extend `tests/tlsf_getopt.h` to match common getopt forms: clustered flags (`-cq`), attached args (`-s64`), cluster ending with a parameterized option (`-cs64` / `-cs 64`), and `--` as a terminator. Track cluster position with `char_pos`, advance past exhausted elements, return `?` for unknown or missing-arg options. Make `tlsf_getopt()` static inline to avoid multiple-definition hazards.
- Cache Windows QPC frequency once and derive nanoseconds from the cached value in both harnesses.
- Make peak RSS best-effort: `get_systemmem_usage` returns 0 on success, -1 on failure; print “unavailable” when missing and use `PRIu64` for formatting.
- Update CI to pass flags explicitly to `bench_tlsf.exe` and `wcet_tlsf.exe`.

**Rollout**
- Invocations must use flags only; positional operands now fail. Example: replace `bench 64 -l 100000` with `bench -s 64 -l 100000`.

<sup>Written for commit 6668069b33d53188ca0e01951b7e3b2c9e250934. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/tlsf-bsd/pull/31?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

