### PR TITLE
Fixes invalid arena handling in allocator resize and prevents overflow

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,38 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[Makefile]
+indent_style = tab
+indent_size = 4
+
+[mk/*]
+indent_style = tab
+indent_size = 4
+
+[*.[ch]]
+indent_style = space
+indent_size = 4
+max_line_length = 80
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+# Tabs, not spaces: the repo's shell scripts are tab-indented and shfmt (run by
+# .ci/check-format.sh) reads this file in preference to its own flags, so
+# 'indent_style = space' here makes the CI format job fail.
+[*.sh]
+indent_style = tab
+indent_size = 4
+
+[*.hook]
+indent_style = space
+indent_size = 4
+
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,10 @@ OBJS := $(addprefix $(OUT)/,$(OBJS))
 
 THREAD_OBJS = $(OUT)/tlsf_thread.o
 
-deps := $(OBJS:%.o=%.o.d)
+# Every rule that passes -MMD -MF must be listed, or 'clean' leaves its dep
+# file behind. $(OUT)/test is deliberately absent: its rule emits no dep file.
+deps := $(OBJS:%.o=%.o.d) $(THREAD_OBJS:%.o=%.o.d) \
+	$(OUT)/bench.d $(OUT)/wcet.d $(THREAD_TARGETS:%=%.d)
 
 $(OUT)/test: $(OBJS) tests/test.c
 	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
@@ -123,6 +126,7 @@ clean:
 	$(RM) $(TARGETS) $(THREAD_TARGETS) $(OBJS) $(THREAD_OBJS) $(deps)
 	$(RM) $(OUT)/wcet_raw.csv $(OUT)/wcet_summary.csv
 	$(RM) $(OUT)/wcet_boxplot.png $(OUT)/wcet_histogram.png
+	$(RM) -r $(OUT)/*.dSYM
 
 .PHONY: all check clean verify bench bench-quick wcet wcet-quick wcet-plot
 

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,8 @@ check: $(TARGETS) $(THREAD_TARGETS)
 # Two classes of WP warning are expected and cannot be annotated away:
 #   "Skipped RTE guards" for \aligned and \valid_function, which the Typed
 #   model does not support, and "Cast with incompatible pointers types" for the
-#   char* block arithmetic in block_payload()/to_block(). The Bytes model models
+#   char* block arithmetic in block_payload()/to_block() and in the assigns
+#   clause of block_poison_free(). The Bytes model models
 #   those casts natively and silences the warnings, but it is experimental and
 #   leaves two goals unproved, so Typed+nocast stays.
 verify:

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ OUT = build
 FRAMAC ?= frama-c
 
 # Leaf helpers carrying ACSL contracts. No caller of these is in the list yet,
-# so every `requires` here is an assumed hypothesis rather than a discharged
-# one: `make verify` proves the helpers consistent with their own contracts,
+# so every 'requires' here is an assumed hypothesis rather than a discharged
+# one: 'make verify' proves the helpers consistent with their own contracts,
 # not that the allocator establishes those contracts at the call sites. Extend
 # upward (block_split, block_absorb, block_set_free, ...) to close that gap.
 WP_FUNCTIONS = \

--- a/include/tlsf.h
+++ b/include/tlsf.h
@@ -150,7 +150,7 @@ typedef struct {
     uint32_t fl, sl[_TLSF_FL_COUNT];
 
     /* Fixed pool: memory is caller-owned (tlsf_pool_init) and the arena can
-     * neither grow nor shrink. Orthogonal to `arena`, which is always the
+     * neither grow nor shrink. Orthogonal to 'arena', which is always the
      * current base address once the pool has any memory.
      */
     bool fixed;

--- a/src/tlsf.c
+++ b/src/tlsf.c
@@ -481,6 +481,8 @@ INLINE tlsf_block_t *block_from_payload(void *ptr)
  */
 /*@
   requires tlsf_aligned_header(block);
+  assigns *((char *)block + BLOCK_HEADER_OFFSET + BLOCK_OVERHEAD +
+            (0 .. block->header - block->header % ALIGN_SIZE - 1));
 */
 INLINE void block_poison_free(tlsf_block_t *block)
 {

--- a/src/tlsf.c
+++ b/src/tlsf.c
@@ -129,7 +129,7 @@
  */
 #define BLOCK_PAYLOAD_OVERHEAD (sizeof(struct tlsf_block *) * 3)
 
-/* Forcing always_inline costs 168 bytes of .text over plain `static inline` at
+/* Forcing always_inline costs 168 bytes of .text over plain 'static inline' at
  * -O2 (6236 vs 6068, clang/arm64), because the compiler already inlines these
  * helpers on its own. Median malloc_worst latency is identical at 42 ticks
  * either way; the tails are scheduler noise. Override with -DINLINE="static
@@ -434,7 +434,7 @@ INLINE size_t align_up(size_t x, size_t align)
  *
  * Instead, we compute the alignment offset and use pointer arithmetic:
  *   p + (aligned_addr - addr)
- * This preserves provenance because the result is derived from `p`.
+ * This preserves provenance because the result is derived from 'p'.
  *
  * Note: uintptr_t is the canonical type for pointer-to-integer round-trips.
  */
@@ -719,7 +719,7 @@ INLINE void mapping(size_t size, uint32_t *fl, uint32_t *sl)
 
     /* SL: linear index for small, logarithmic for large. Clamp the shift to
      * avoid undefined behavior when t < SL_SHIFT; the garbage result is masked
-     * out by `small`.
+     * out by 'small'.
      */
     uint32_t shift =
         (t - (uint32_t) SL_SHIFT) & ((uint32_t) (_TLSF_SIZE_WIDTH - 1));
@@ -897,14 +897,14 @@ INLINE tlsf_block_t *block_split(tlsf_block_t *block, size_t size)
     return rest;
 }
 
-/* Absorb a free block's storage into an adjacent previous free block. `block`
+/* Absorb a free block's storage into an adjacent previous free block. 'block'
  * is not const: its successor is resolved through it, and that successor is
  * then written. Taking it const would only move a const-discarding cast inside.
  *
- * Resolving next from `block` before growing `prev` (rather than from `prev`
+ * Resolving next from 'block' before growing 'prev' (rather than from 'prev'
  * after, as the size arithmetic would also allow) keeps the successor lookup
  * off a header that is mid-update. The two agree only because a block's
- * successor sits at `block + BLOCK_HEADER_OFFSET + block_size(block)` and
+ * successor sits at 'block + BLOCK_HEADER_OFFSET + block_size(block)' and
  * BLOCK_HEADER_OFFSET == BLOCK_OVERHEAD, which the static assert above pins.
  */
 INLINE tlsf_block_t *block_absorb(tlsf_block_t *prev, tlsf_block_t *block)
@@ -1050,8 +1050,8 @@ static void bins_reset(tlsf_t *t)
             t->block[i][j] = &t->block_null;
 }
 
-/* Lay out a pool as a single free block of `free_size` payload bytes followed
- * by the terminating zero-size sentinel. `start` is the first payload byte; the
+/* Lay out a pool as a single free block of 'free_size' payload bytes followed
+ * by the terminating zero-size sentinel. 'start' is the first payload byte; the
  * block header sits one word below it, and that block's prev field lies outside
  * the pool and is never read.
  */

--- a/src/tlsf.c
+++ b/src/tlsf.c
@@ -1324,10 +1324,16 @@ void *tlsf_malloc(tlsf_t *t, size_t size)
         if (sl_map) {
             uint32_t found_sl = bitmap_ffs(sl_map);
 
-            /* Use the bin's minimum size so mapping(block_size) returns the
-             * same bin on free.
+            /* Keep 'size' at the request. bitmap_ffs may land on a bin above
+             * the one the request maps to, and inflating the allocation to that
+             * bin's size hands out the whole block instead of trimming it,
+             * which is the defect block_find_free() documents below. The
+             * request is already ALIGN_SIZE-aligned and at least
+             * BLOCK_SIZE_MIN, and FL=0 bins are ALIGN_SIZE-spaced, so it is
+             * already on a bin boundary: a trimmed block still lands in the bin
+             * a same-size request will search, and an untrimmable one keeps its
+             * own size and maps to its own bin.
              */
-            size = (size_t) found_sl << ALIGN_SHIFT;
             tlsf_block_t *block = t->block[0][found_sl];
             remove_free_block(t, block, 0, found_sl);
             return block_use(t, block, size);

--- a/src/tlsf.c
+++ b/src/tlsf.c
@@ -192,6 +192,14 @@ TLSF_STATIC_ASSERT(FL_COUNT == _TLSF_FL_COUNT, "invalid level configuration");
 TLSF_STATIC_ASSERT(SL_COUNT == _TLSF_SL_COUNT, "invalid level configuration");
 TLSF_STATIC_ASSERT(TLSF_SPLIT_THRESHOLD >= BLOCK_SIZE_MIN,
                    "split threshold must be at least minimum block size");
+
+/* Without an upper bound, a documented-but-absurd threshold wraps
+ * BLOCK_OVERHEAD + TLSF_SPLIT_THRESHOLD + size in block_can_trim() and makes it
+ * accept blocks it must not.
+ */
+TLSF_STATIC_ASSERT(TLSF_SPLIT_THRESHOLD <= BLOCK_SIZE_MAX,
+                   "split threshold must not overflow block size arithmetic");
+
 TLSF_STATIC_ASSERT(_TLSF_FL_COUNT >= 1,
                    "TLSF_MAX_POOL_BITS too small for this architecture");
 TLSF_STATIC_ASSERT(FL_MAX < _TLSF_SIZE_WIDTH,
@@ -581,14 +589,19 @@ MAYBE_UNUSED INLINE bool block_can_split(const tlsf_block_t *block, size_t size)
  */
 /*@
   requires tlsf_aligned_header(block);
-  requires size <= SIZE_MAX - BLOCK_OVERHEAD - TLSF_SPLIT_THRESHOLD;
   assigns \nothing;
   ensures \result ==>
             block->header >= BLOCK_OVERHEAD + TLSF_SPLIT_THRESHOLD + size;
 */
 INLINE bool block_can_trim(const tlsf_block_t *block, size_t size)
 {
-    return block_size(block) >= BLOCK_OVERHEAD + TLSF_SPLIT_THRESHOLD + size;
+    /* Subtraction form so the comparison cannot wrap for any 'size', even if
+     * the TLSF_SPLIT_THRESHOLD bound above is later relaxed. min_total is a
+     * compile-time constant the static assert keeps well below SIZE_MAX.
+     */
+    size_t bsize = block_size(block);
+    const size_t min_total = BLOCK_OVERHEAD + TLSF_SPLIT_THRESHOLD;
+    return bsize >= min_total && size <= bsize - min_total;
 }
 
 /* The flag nibble is header % ALIGN_SIZE: bit 0 is FREE, bit 1 is PREV_FREE.

--- a/src/tlsf_thread.c
+++ b/src/tlsf_thread.c
@@ -53,7 +53,7 @@ static void *arena_alloc(tlsf_arena_t *a, size_t align, size_t size)
                  : tlsf_malloc(&a->pool, size);
 }
 
-/* Try to allocate from arenas other than `skip`, using non-blocking try-lock
+/* Try to allocate from arenas other than 'skip', using non-blocking try-lock
  * first, then blocking acquire.
  *
  * Returns NULL if all arenas are exhausted.

--- a/tests/test.c
+++ b/tests/test.c
@@ -37,23 +37,107 @@ static inline size_t get_page_size(void)
     GetSystemInfo(&si);
     return (size_t) si.dwPageSize;
 #else
-    return (size_t) sysconf(_SC_PAGESIZE);
+    long page_size = sysconf(_SC_PAGESIZE);
+
+    /* Zero is as unusable as a negative return, since PAGE is a divisor below.
+     * Report with fputs rather than perror: sysconf may return -1 for an
+     * indeterminate limit without setting errno.
+     */
+    if (page_size <= 0) {
+        fputs("sysconf(_SC_PAGESIZE) returned an unusable page size\n", stderr);
+        exit(EXIT_FAILURE);
+    }
+    return (size_t) page_size;
 #endif
 }
 
+/* Size the virtual address space window that tlsf_resize() hands out. Called
+ * from tlsf_resize() itself so PAGE can never be read before it is set. 64-bit:
+ * 1 GB is sufficient and safe. 32-bit: 128 MB to avoid VA space exhaustion
+ * (user space is 2-3 GB).
+ */
+static void page_init(void)
+{
+    if (PAGE)
+        return;
+    PAGE = get_page_size();
+#if _TLSF_SIZE_WIDTH == 64 || defined(__LP64__) || defined(_LP64)
+    MAX_PAGES = ((size_t) 1 << 30) / PAGE;
+#else
+    MAX_PAGES = ((size_t) 128 << 20) / PAGE;
+#endif
+}
+
+/* Platform primitives behind tlsf_resize(). Each does one job: reserve the
+ * address window, hand physical pages back, and make pages writable before the
+ * allocator touches them. Keeping them this small is what lets the resize
+ * driver below exist in one copy instead of two that must be kept in step.
+ *
+ * pages_reserve() reports failure as NULL on both platforms, so the POSIX
+ * MAP_FAILED sentinel never escapes it and cannot be mistaken for an arena.
+ */
 #if defined(_WIN32) || defined(WIN32) || defined(__WIN32__) || defined(_WIN64)
+/* VirtualAlloc with MEM_RESERVE is the analogue of mmap with MAP_NORESERVE. */
+static void *pages_reserve(size_t bytes)
+{
+    void *addr = VirtualAlloc(NULL, bytes, MEM_RESERVE, PAGE_READWRITE);
+    if (!addr)
+        fprintf(stderr, "VirtualAlloc reserve failed: %lu\n", GetLastError());
+    return addr;
+}
+
+/* MEM_DECOMMIT is the analogue of madvise(MADV_DONTNEED): the address stays
+ * reserved, the physical pages go back. Best-effort, see pages_release() use.
+ */
+static void pages_release(void *addr, size_t bytes)
+{
+    if (!VirtualFree(addr, bytes, MEM_DECOMMIT))
+        fprintf(stderr, "VirtualFree decommit failed: %lu\n", GetLastError());
+}
+
+static bool pages_commit(void *addr, size_t bytes)
+{
+    if (VirtualAlloc(addr, bytes, MEM_COMMIT, PAGE_READWRITE))
+        return true;
+    fprintf(stderr, "VirtualAlloc commit failed: %lu\n", GetLastError());
+    return false;
+}
+#else
+static void *pages_reserve(size_t bytes)
+{
+    void *addr = mmap(0, bytes, PROT_READ | PROT_WRITE,
+                      MAP_ANONYMOUS | MAP_PRIVATE | MAP_NORESERVE, -1, 0);
+    if (addr == MAP_FAILED) {
+        perror("mmap");
+        return NULL;
+    }
+    return addr;
+}
+
+static void pages_release(void *addr, size_t bytes)
+{
+    if (madvise(addr, bytes, MADV_DONTNEED) != 0)
+        perror("madvise");
+}
+
+static bool pages_commit(void *addr, size_t bytes)
+{
+    /* Nothing to do: the MAP_NORESERVE mapping is already writable and the
+     * kernel backs each page on first touch.
+     */
+    (void) addr;
+    (void) bytes;
+    return true;
+}
+#endif
+
 void *tlsf_resize(tlsf_t *t, size_t req_size)
 {
     (void) t;
+    page_init();
 
-    /* This is analogue mmap with flag MAP_NORESERVE to VirtualAlloc with
-     * MEM_RESERVE
-     */
     if (!start_addr) {
-        start_addr = VirtualAlloc(NULL, MAX_PAGES * PAGE,
-                                  MEM_RESERVE, /* Only reserve address space */
-                                  PAGE_READWRITE /* Rights for read and write */
-        );
+        start_addr = pages_reserve(MAX_PAGES * PAGE);
         if (!start_addr)
             return NULL;
     }
@@ -64,52 +148,19 @@ void *tlsf_resize(tlsf_t *t, size_t req_size)
 
     if (req_pages != curr_pages) {
         if (req_pages < curr_pages) {
-            /* Analogue for madvise(..., MADV_DONTNEED) to VirtualFree with
-             * MEM_DECOMMIT Free physical memory (commit), with reserved
-             * addresses
+            /* Best-effort: a failed release leaves the pages resident but does
+             * not affect allocator state, so curr_pages advances either way.
              */
-            VirtualFree((char *) start_addr + PAGE * req_pages,
-                        (size_t) (curr_pages - req_pages) * PAGE,
-                        MEM_DECOMMIT /* physical pages to zero */
-            );
-        } else {
-            /* Commit reserved memory */
-            void *commit_ptr = VirtualAlloc(
-                start_addr,                   /* base address is the same */
-                req_pages * PAGE, MEM_COMMIT, /* Commit new pages */
-                PAGE_READWRITE);
-            if (!commit_ptr)
-                return NULL;
+            pages_release((char *) start_addr + PAGE * req_pages,
+                          (curr_pages - req_pages) * PAGE);
+        } else if (!pages_commit(start_addr, req_pages * PAGE)) {
+            return NULL;
         }
-
         curr_pages = req_pages;
     }
 
     return start_addr;
 }
-#else
-void *tlsf_resize(tlsf_t *t, size_t req_size)
-{
-    (void) t;
-
-    if (!start_addr)
-        start_addr = mmap(0, MAX_PAGES * PAGE, PROT_READ | PROT_WRITE,
-                          MAP_ANONYMOUS | MAP_PRIVATE | MAP_NORESERVE, -1, 0);
-
-    size_t req_pages = (req_size + PAGE - 1) / PAGE;
-    if (req_pages > MAX_PAGES)
-        return 0;
-
-    if (req_pages != curr_pages) {
-        if (req_pages < curr_pages)
-            madvise((char *) start_addr + PAGE * req_pages,
-                    (size_t) (curr_pages - req_pages) * PAGE, MADV_DONTNEED);
-        curr_pages = req_pages;
-    }
-
-    return start_addr;
-}
-#endif
 
 static void random_test(tlsf_t *t, size_t spacelen, const size_t cap)
 {
@@ -1114,16 +1165,6 @@ static void pool_reset_test(void)
 
 int main(void)
 {
-    PAGE = get_page_size();
-
-    /* Virtual address space reservation for testing. 64-bit: 1GB is sufficient
-     * and safe 32-bit: 128MB to avoid VA space exhaustion (user space is 2-3GB)
-     */
-#if _TLSF_SIZE_WIDTH == 64 || defined(__LP64__) || defined(_LP64)
-    MAX_PAGES = ((size_t) 1 << 30) / PAGE; /* 1 GB */
-#else
-    MAX_PAGES = ((size_t) 128 << 20) / PAGE; /* 128 MB */
-#endif
     tlsf_t t = TLSF_INIT;
 
     const char *seed_env = getenv("TLSF_TEST_SEED");

--- a/tests/test.c
+++ b/tests/test.c
@@ -203,10 +203,16 @@ static void random_test(tlsf_t *t, size_t spacelen, const size_t cap)
         if (i % check_stride == 0)
             tlsf_check(t);
 
-        /* Fill with magic (only when testing up to 1MB). */
+        /* Fill with magic (only when testing up to 1MB). The fill runs over the
+         * usable size rather than the requested length, so it doubles as the
+         * check on tlsf_usable_size(): under-reporting trips the assert, and
+         * over-reporting corrupts a neighbour that tlsf_check() then sees.
+         */
         uint8_t *data = (uint8_t *) p[i];
+        size_t usable = tlsf_usable_size(data);
+        assert(usable >= len);
         if (spacelen <= 1024 * 1024)
-            memset(data, 0, len);
+            memset(data, 0, usable);
         data[0] = 0xa5;
 
         i++;

--- a/tests/test.c
+++ b/tests/test.c
@@ -981,6 +981,66 @@ static void pool_utilization_test(void)
  * backed with memory, so the boundary is exercised under a reduced
  * TLSF_MAX_POOL_BITS. CI covers 20 and 24.
  */
+static void small_bin_trim_test(void)
+{
+    printf("Small-bin trim test: ");
+    fflush(stdout);
+
+    /* The FL=0 fast path in tlsf_malloc() may satisfy a request from a bin
+     * above the one the request maps to. It must still trim the block to the
+     * request. Inflating the allocation to the found bin's size hands out the
+     * whole block, which is the defect block_find_free() documents for the
+     * generic path; the fast path has reintroduced it once already.
+     *
+     * Everything here is derived from _TLSF_FL_SHIFT rather than written as a
+     * literal. ALIGN_SIZE differs by word size, so the fast path covers sizes
+     * below 256 on 64-bit but below 128 on 32-bit, and a hard-coded seed size
+     * silently stops testing the fast path on one of them.
+     */
+    const size_t fast_path_max = (size_t) 1 << _TLSF_FL_SHIFT;
+    const size_t seed_req = fast_path_max - fast_path_max / 4;
+
+    static char pool[TLSF_TEST_POOL_CLAMP(64 * 1024)];
+    tlsf_t t;
+    assert(tlsf_pool_init(&t, pool, sizeof(pool)));
+
+    /* Seed one large FL=0 free block, guarded so it cannot coalesce away. */
+    void *big = tlsf_malloc(&t, seed_req);
+    void *guard = tlsf_malloc(&t, 64);
+    assert(big && guard);
+    const size_t seeded = tlsf_usable_size(big);
+
+    /* Fail loudly if the seed did not land in FL=0: the rest of this test
+     * proves nothing about the fast path unless it did.
+     */
+    assert(seeded >= seed_req);
+    assert(seeded < fast_path_max);
+    tlsf_free(&t, big);
+    tlsf_check(&t);
+
+    /* A minimal request must not swallow the seeded block. */
+    void *probe = tlsf_malloc(&t, 1);
+    assert(probe);
+    const size_t got = tlsf_usable_size(probe);
+    assert(got < seeded);
+
+    /* The trimmed remainder must still be allocatable. TLSF_TEST_BLOCK_COST
+     * over-subtracts, which only makes the request more conservative.
+     */
+    assert(seeded - got > TLSF_TEST_BLOCK_COST);
+    void *rest = tlsf_malloc(&t, seeded - got - TLSF_TEST_BLOCK_COST);
+    assert(rest);
+    tlsf_check(&t);
+
+    tlsf_free(&t, rest);
+    tlsf_free(&t, probe);
+    tlsf_free(&t, guard);
+    tlsf_check(&t);
+
+    printf("%zu-byte FL=0 bin served a minimal request as %zu bytes, done\n",
+           seeded, got);
+}
+
 static void pool_ceiling_test(void)
 {
     printf("Pool ceiling test: ");
@@ -1206,6 +1266,9 @@ int main(void)
 
     /* Run free/realloc address reuse test */
     reuse_same_address_test();
+
+    /* Run small-bin trim test */
+    small_bin_trim_test();
 
     /* Run pool ceiling test */
     pool_ceiling_test();


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes invalid arena handling in tlsf_resize and stops the small-bin (FL=0) fast path from over-allocating. Old POSIX resize could pass MAP_FAILED as the arena and the fast path inflated requests to the bin size; the new unified resize returns NULL on failure and the fast path trims to the request, improving correctness and small‑pool utilization.

- Bound TLSF_SPLIT_THRESHOLD at BLOCK_SIZE_MAX and rewrote block_can_trim in subtraction form to prevent overflow.
- Unified resize via pages_reserve/pages_commit/pages_release; reject unusable page sizes; initialize PAGE/MAX_PAGES inside tlsf_resize; treat release as best‑effort; POSIX commit is a no‑op; add diagnostics.
- Tests: random_test now validates and fills over tlsf_usable_size; new small_bin_trim_test targets the FL=0 path on 32‑ and 64‑bit; page init moved into resize; renamed a Windows‑conflicting local.
- Verification/Build: added an assigns clause to block_poison_free; Makefile clean removes all dep files and .dSYM; added .editorconfig; comments now quote identifiers with apostrophes.

**Migration**
- If you define TLSF_SPLIT_THRESHOLD or TLSF_MAX_POOL_BITS, ensure the split threshold is within [BLOCK_SIZE_MIN, BLOCK_SIZE_MAX] and the configuration yields a positive FL_COUNT, or the build will fail.

<sup>Written for commit 586c30d5936e60e9fb7ed7b99a497ed0f6db903b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/tlsf-bsd/pull/32?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

