### PR TITLE
Makes allocator behavior safer and verifiable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ WP_FUNCTIONS = \
 	block_set_prev_free,block_set_free_at,free_list_link, \
 	free_list_unlink,bin_set_head, \
 	bins_reset,adjust_size,block_prev,block_poison_free,check_sentinel, \
-	bitmap_ffs,log2floor,block_next,round_block_size
+	bitmap_ffs,log2floor,block_next,round_block_size,align_offset
 
 TARGETS = \
 	test \

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,8 @@ WP_FUNCTIONS = \
 	block_set_prev_free,block_set_free_at,free_list_link, \
 	free_list_unlink,bin_set_head, \
 	bins_reset,adjust_size,block_prev,block_poison_free,check_sentinel, \
-	bitmap_ffs,log2floor,block_next,round_block_size,align_offset,mapping
+	bitmap_ffs,log2floor,block_next,round_block_size,align_offset,mapping, \
+	tlsf_pool_reset,remove_free_block,insert_free_block
 
 TARGETS = \
 	test \

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ WP_FUNCTIONS = \
 	block_set_prev_free,block_set_free_at,free_list_link, \
 	free_list_unlink,bin_set_head, \
 	bins_reset,adjust_size,block_prev,block_poison_free,check_sentinel, \
-	bitmap_ffs,log2floor,block_next,round_block_size,align_offset
+	bitmap_ffs,log2floor,block_next,round_block_size,align_offset,mapping
 
 TARGETS = \
 	test \

--- a/include/tlsf.h
+++ b/include/tlsf.h
@@ -20,8 +20,8 @@ extern "C" {
 
 /* IMPORTANT: the configuration macros below (TLSF_MAX_POOL_BITS in particular)
  * change the layout and size of tlsf_t, which callers allocate themselves.
- * Every translation unit in a build -- src/tlsf.c and every consumer -- must
- * see identical definitions. A mismatch is not diagnosed: the struct silently
+ * Every translation unit in a build (src/tlsf.c and every consumer) must see
+ * identical definitions. A mismatch is not diagnosed: the struct silently
  * differs in size (8376 vs 3440 bytes for the default vs TLSF_MAX_POOL_BITS=20
  * on 64-bit) and accesses land at the wrong offsets. Define them in the build
  * system, never in a single .c file.
@@ -67,9 +67,16 @@ extern "C" {
 #endif
 
 /* Configurable maximum pool size: define TLSF_MAX_POOL_BITS to clamp the
- * first-level index, reducing the tlsf_t control structure size. Pool cannot
- * exceed 2^TLSF_MAX_POOL_BITS bytes. E.g. -DTLSF_MAX_POOL_BITS=20 for a 1MB-max
- * pool.
+ * first-level index, which shrinks the tlsf_t control structure. On 64-bit,
+ * -DTLSF_MAX_POOL_BITS=20 takes tlsf_t from 8376 down to 3440 bytes.
+ *
+ * The clamp bounds a dynamic arena at 2^TLSF_MAX_POOL_BITS bytes. It does not
+ * bound a fixed pool at the same figure: tlsf_pool_init() accepts only about
+ * half that, because the pool's single initial free block is itself capped at
+ * 2^(_TLSF_FL_MAX - 1). For an ALIGN_SIZE-aligned pointer at
+ * TLSF_MAX_POOL_BITS=20 the largest accepted region is 524304 bytes, not 1 MB.
+ * An unaligned pointer may carry up to ALIGN_SIZE-1 further bytes that are
+ * skipped for alignment. TLSF_MAX_POOL_BYTES below states the limit.
  */
 #ifdef TLSF_MAX_POOL_BITS
 #define _TLSF_FL_MAX TLSF_MAX_POOL_BITS
@@ -100,10 +107,14 @@ extern "C" {
  */
 #define TLSF_MAX_POOL_BYTES \
     (((size_t) 1 << (_TLSF_FL_MAX - 1)) + 2 * sizeof(size_t))
+
+/* An allocator with no arena yet. The first tlsf_malloc() grows one through
+ * tlsf_resize(), so an instance initialized this way needs that callback.
+ */
 #define TLSF_INIT ((tlsf_t) {.size = 0})
 
-/* TLSF_INIT_STATIC is need to be used instead of TLSF_INIT for initializing
- * static objects for cross platform compatibility
+/* The same value for objects with static storage duration. MSVC rejects a
+ * compound literal as a static initializer, so it gets the bare brace form.
  */
 #if defined(_MSC_VER)
 #define TLSF_INIT_STATIC {.size = 0}
@@ -133,12 +144,11 @@ extern "C" {
 
 /* Block header structure.
  *
- * prev: Pointer to the previous physical block. Only valid when the
- *            previous block is free; physically stored at the tail of that
- *            block's payload.
- * header: Size (upper bits) | status bits (lower 2 bits). next_free: Next block
- * in the same free list (only valid when free). prev_free: Previous block in
- * the same free list (only valid when free).
+ * @prev : Pointer to the previous physical block. Only valid when the previous
+ *         block is free; physically stored at the tail of that block's payload.
+ * @header : Size (upper bits) | status bits (lower 2 bits).
+ * @next_free : Next block in the same free list (only valid when free).
+ * @prev_free : Previous block in the same free list (only valid when free).
  */
 struct tlsf_block {
     struct tlsf_block *prev;
@@ -147,22 +157,34 @@ struct tlsf_block {
 };
 
 typedef struct {
+    /* First-level bitmap, plus one second-level bitmap per first-level class. A
+     * set bit means that bin holds at least one free block, which is what makes
+     * the search for a fit O(1).
+     */
     uint32_t fl, sl[_TLSF_FL_COUNT];
 
-    /* Fixed pool: memory is caller-owned (tlsf_pool_init) and the arena can
-     * neither grow nor shrink. Orthogonal to 'arena', which is always the
-     * current base address once the pool has any memory.
+    /* Fixed pool: memory is caller-owned (tlsf_pool_init) and the allocator
+     * never calls tlsf_resize(), so the arena never auto-grows and never
+     * shrinks. It can still be extended deliberately, by tlsf_append_pool()
+     * with adjacent memory. Orthogonal to @arena, which is always the current
+     * base address once the pool has any memory.
      */
     bool fixed;
-    void *arena; /* Pool base address; NULL until a dynamic pool first grows */
-    size_t size;
+
+    /* Pool base address. Set by tlsf_pool_init() for a fixed pool; NULL for a
+     * dynamic pool until its first growth.
+     */
+    void *arena;
+    size_t size; /* Arena bytes owned, sentinels included; 0 when there is no
+                  * pool yet
+                  */
     struct tlsf_block *block[_TLSF_FL_COUNT][_TLSF_SL_COUNT];
     struct tlsf_block block_null; /* Free-list sentinel (absorbs writes) */
 } tlsf_t;
 
 /* The header word immediately precedes a payload pointer. Its validity is the
- * memory-safety condition shared by free and realloc; allocation ownership is
- * a semantic caller obligation, documented on those functions.
+ * memory-safety condition shared by free and realloc; allocation ownership is a
+ * semantic caller obligation, documented on those functions.
  */
 /*@
   predicate tlsf_payload_header{L}(void *ptr) =
@@ -175,6 +197,14 @@ typedef struct {
  * tlsf_pool_init() need not provide this function. A weak default returning
  * NULL is provided in tlsf.c; dynamic pool users MUST override it, otherwise
  * allocations will silently fail.
+ *
+ * The first successful resize establishes the arena base. While the arena is
+ * live, every later successful nonzero resize must return that same base and
+ * preserve the surviving prefix at the same offsets. Returning NULL must leave
+ * the old mapping intact. A resize to zero releases the arena and ends its
+ * lifetime; the next nonzero resize starts over and may establish a different
+ * base. The callback must not mutate @t; allocator state is owned by the
+ * allocator.
  */
 /*@
   requires \valid(t);
@@ -186,15 +216,15 @@ void *tlsf_resize(tlsf_t *t, size_t size);
 /**
  * Allocate memory with a specified alignment.
  *
- * @param t The TLSF allocator instance
- * @param align Alignment in bytes; must be a non-zero power of two
- * @param size Requested allocation size in bytes; need not be a multiple of
- *              @align (follows POSIX posix_memalign semantics; C11
- *              aligned_alloc required size % align == 0 but C23 and
- *              common implementations dropped that constraint)
- * @return Pointer to at least @size bytes aligned to @align, or NULL on
- *         failure.  A zero @size request returns a unique minimum-sized
- *         allocation (consistent with tlsf_malloc).
+ * @t : The TLSF allocator instance
+ * @align : Alignment in bytes; must be a non-zero power of two
+ * @size : Requested allocation size in bytes; need not be a multiple of @align
+ * (follows POSIX posix_memalign semantics; C11 aligned_alloc required size %
+ * align == 0 but C23 and common implementations dropped that constraint)
+ *
+ * Return Pointer to at least @size bytes aligned to @align, or NULL on failure.
+ * A zero @size request returns a unique minimum-sized allocation (consistent
+ * with tlsf_malloc).
  */
 /*@
   requires \valid(t);
@@ -204,25 +234,27 @@ void *tlsf_resize(tlsf_t *t, size_t size);
 void *tlsf_aalloc(tlsf_t *t, size_t align, size_t size);
 
 /**
- * Append a memory block to an existing pool, potentially coalescing with the
- * last block if it's free.
+ * Extend an existing pool with more memory, coalescing with the pool's last
+ * block when that block is free. Works for fixed and dynamic pools alike.
  *
- * Returns the number of bytes actually used from the memory block for pool
- * expansion.
+ * @mem, rounded up to ALIGN_SIZE, must equal the current pool end. A region
+ * that does not abut the pool is rejected, and that is the usual reason for a 0
+ * return. Bytes lost to that rounding and to the new sentinel are not handed
+ * back, so the return value can be less than @size.
  *
- * @tlsf : The TLSF allocator instance
+ * @t : The TLSF allocator instance
  * @mem : Pointer to the memory block to append
  * @size : Size of the memory block in bytes
  *
  * Return Number of bytes used from the memory block, 0 on failure
  */
 /*@
-  requires \valid(tlsf);
+  requires \valid(t);
   requires mem != \null && size != 0 ==>
     \valid(((char *)mem) + (0 .. size - 1));
   ensures \result <= size;
 */
-size_t tlsf_append_pool(tlsf_t *tlsf, void *mem, size_t size);
+size_t tlsf_append_pool(tlsf_t *t, void *mem, size_t size);
 
 /**
  * Initialize the allocator with a fixed-size memory pool. The pool will not
@@ -233,7 +265,12 @@ size_t tlsf_append_pool(tlsf_t *tlsf, void *mem, size_t size);
  * Multiple independent instances are supported by initializing separate tlsf_t
  * structures with their own memory regions.
  *
- * @t : The TLSF allocator instance (will be zero-initialized)
+ * On success @t is zero-initialized before the pool is laid out. On failure @t
+ * is left exactly as it was, so a rejected re-init cannot destroy a live arena;
+ * a caller that ignores the return value therefore inherits whatever @t already
+ * held, including indeterminate bytes for a fresh automatic object.
+ *
+ * @t : The TLSF allocator instance
  * @mem : Pointer to the memory region to use as the pool
  * @bytes : Total size of the memory region in bytes
  *
@@ -269,12 +306,12 @@ void tlsf_pool_reset(tlsf_t *t);
 /**
  * Allocate memory from the pool.
  *
- * @param t The TLSF allocator instance
- * @param size Requested allocation size in bytes. A zero @size request
- *             returns a unique minimum-sized allocation (POSIX-compatible
- *             behavior), not NULL.
- * @return Pointer to at least @size bytes, aligned to ALIGN_SIZE (8 on
- *         64-bit, 4 on 32-bit), or NULL on failure.
+ * @t : The TLSF allocator instance
+ * @size : Requested allocation size in bytes. A zero @size request returns a
+ * unique minimum-sized allocation (POSIX-compatible behavior), not NULL.
+ *
+ * Return Pointer to at least @size bytes, aligned to ALIGN_SIZE (8 on 64-bit, 4
+ * on 32-bit), or NULL on failure.
  */
 /*@
   requires \valid(t);
@@ -282,6 +319,25 @@ void tlsf_pool_reset(tlsf_t *t);
 */
 void *tlsf_malloc(tlsf_t *t, size_t size);
 
+/**
+ * Resize an existing allocation, preserving its contents up to the smaller of
+ * the old and new sizes.
+ *
+ * Two calls are aliases for other entry points: a NULL @mem allocates, and a
+ * zero @size frees @mem and returns NULL. Note the latter differs from C's
+ * realloc, where the same call is implementation-defined (C17) or undefined
+ * (C23).
+ *
+ * The block may be grown in place, slid backward onto a free predecessor, or
+ * relocated, so the returned pointer need not equal @mem. On failure NULL is
+ * returned and @mem is left allocated and intact.
+ *
+ * @t : The TLSF allocator instance
+ * @mem : Pointer from tlsf_malloc/aalloc/realloc, or NULL
+ * @size : Requested new size in bytes
+ *
+ * Return Pointer to the resized allocation, or NULL on failure or zero @size
+ */
 /*@
   requires \valid(t);
   requires mem != \null ==> tlsf_payload_header(mem);
@@ -290,7 +346,14 @@ void *tlsf_malloc(tlsf_t *t, size_t size);
 void *tlsf_realloc(tlsf_t *t, void *mem, size_t size);
 
 /**
- * Releases the previously allocated memory, given the pointer.
+ * Release an allocation and coalesce it with any free physical neighbors.
+ *
+ * A NULL @mem is a no-op. Passing a pointer that was already freed, or one that
+ * did not come from this allocator, is undefined: it corrupts metadata silently
+ * in release builds and trips an assertion in debug builds.
+ *
+ * @t : The TLSF allocator instance
+ * @mem : Pointer from tlsf_malloc/aalloc/realloc, or NULL
  */
 /*@
   requires \valid(t);
@@ -301,10 +364,11 @@ void tlsf_free(tlsf_t *t, void *mem);
 /**
  * Return the usable size of an existing allocation. The usable size may exceed
  * the originally requested size due to alignment rounding and bin-class
- * quantization. Equivalent to POSIX malloc_usable_size().
+ * quantization. The analogue of glibc's malloc_usable_size(); POSIX specifies
+ * no such function.
  *
  * @ptr : Pointer previously returned by tlsf_malloc/aalloc/realloc. Behavior is
- * undefined if ptr has been freed.
+ *        undefined if ptr has been freed.
  *
  * Return Usable payload bytes, or 0 if ptr is NULL
  */
@@ -314,8 +378,20 @@ void tlsf_free(tlsf_t *t, void *mem);
 */
 size_t tlsf_usable_size(void *ptr);
 
+/**
+ * Walk the whole arena and verify its invariants: block linkage, size and
+ * alignment, sentinels, and agreement between the bitmaps and the free lists.
+ *
+ * A violation it reaches prints to stderr and calls abort(); corruption severe
+ * enough to derail the walk itself may fault first. It is a debugging aid, not
+ * an error-reporting API, and it is linear in the number of blocks. Without
+ * TLSF_ENABLE_CHECK it compiles to nothing; see the note at the top of this
+ * header about setting that macro uniformly.
+ *
+ * @t : The TLSF allocator instance
+ */
 #ifdef TLSF_ENABLE_CHECK
-void tlsf_check(tlsf_t *);
+void tlsf_check(tlsf_t *t);
 #else
 static inline void tlsf_check(tlsf_t *t)
 {
@@ -336,11 +412,16 @@ typedef struct {
 } tlsf_stats_t;
 
 /**
- * Collect heap statistics by walking all blocks.
+ * Collect heap statistics by walking every block, so cost is linear in the
+ * block count rather than constant.
+ *
+ * An allocator with no pool yet reports all-zero statistics and succeeds.
+ *
  * @t : The TLSF allocator instance
  * @stats : Output structure to fill with statistics
  *
- * Return 0 on success, -1 if t or stats is NULL
+ * Return 0 on success, -1 if @t or @stats is NULL, or if @t claims a nonzero
+ * size but has no arena
  */
 /*@
   behavior invalid:

--- a/include/tlsf_thread.h
+++ b/include/tlsf_thread.h
@@ -11,9 +11,12 @@
  *
  * Instead of a single coarse mutex around the entire allocator, the pool is
  * split into TLSF_ARENA_COUNT independent sub-pools (arenas), each with its own
- * lock. Threads are mapped to arenas by a hash of their thread identifier, so
- * concurrent allocations from different threads typically hit different locks
- * with zero contention.
+ * lock. An allocation prefers the arena at mix(TLSF_THREAD_HINT()) modulo the
+ * live arena count, so allocations from different threads usually hit different
+ * locks. Nothing guarantees distinct arenas: hints can collide, and an arena
+ * that is locked or full is skipped for another. Where TLSF_THREAD_HINT()
+ * cannot identify a thread it is the constant 0, which funnels every thread to
+ * arena 0 and forfeits the whole benefit; see the lock abstraction below.
  *
  * Thread-safety contract (same as POSIX malloc/free):
  * - Different threads may call any API function concurrently.
@@ -46,7 +49,9 @@ extern "C" {
  *
  * Override ALL six lock macros together before including this header. When
  * providing custom locks, also define TLSF_THREAD_HINT() to return a
- * thread-specific unsigned integer for arena selection.
+ * thread-specific unsigned integer for arena selection. Without it the hint
+ * falls back to the constant 0, every thread selects arena 0, and the per-arena
+ * locking degenerates to a single lock.
  *
  * TLSF_LOCK_INIT must evaluate to an int: 0 on success, non-zero on failure.
  * tlsf_thread_init() checks it and aborts initialization if a lock cannot be
@@ -206,7 +211,8 @@ extern "C" {
  *                   arena can exhaust while others have space).
  *   Fewer arenas -> better memory utilization, higher contention.
  *
- * Must be >= 1. Power of two recommended for efficient hash mapping.
+ * Must be >= 1. Any value works: arena selection takes a modulo of the live
+ * arena count, so a power of two buys nothing here.
  */
 #ifndef TLSF_ARENA_COUNT
 #define TLSF_ARENA_COUNT 4
@@ -228,54 +234,92 @@ TLSF_STATIC_ASSERT((TLSF_CACHELINE_SIZE & (TLSF_CACHELINE_SIZE - 1)) == 0,
 TLSF_MSVC_ALIGN(TLSF_CACHELINE_SIZE) typedef struct {
     tlsf_t pool;
     TLSF_LOCK_T lock;
-    void *base;      /* Arena memory base (for pointer ownership) */
-    size_t capacity; /* Arena memory size in bytes */
+
+    /* Raw chunk handed to this arena. Ownership lookup tests against this
+     * range, not against pool.arena, so it deliberately covers the leading and
+     * trailing bytes that tlsf_pool_init() skipped for alignment.
+     */
+    void *base;
+    size_t capacity;
 } TLSF_GCC_ALIGN(TLSF_CACHELINE_SIZE) tlsf_arena_t;
 
 typedef struct {
     tlsf_arena_t arenas[TLSF_ARENA_COUNT];
-    int count; /* Initialized arena count (<= TLSF_ARENA_COUNT) */
+
+    /* Live arena count, at most TLSF_ARENA_COUNT. Zero before a successful
+     * init, after a failed init, and after tlsf_thread_destroy().
+     */
+    int count;
 } tlsf_thread_t;
 
 /**
  * Initialize from a contiguous memory region, splitting it into up to
- * TLSF_ARENA_COUNT independent sub-pools. The arena count may be reduced if the
- * region is too small to support all arenas.
+ * TLSF_ARENA_COUNT independent sub-pools, one lock each.
+ *
+ * The count is halved while each arena's share would fall below 256 bytes, so
+ * the result is TLSF_ARENA_COUNT divided by a power of two, at least 1. That is
+ * a heuristic, not a guarantee: a chunk can still be too small for a pool, and
+ * then the whole call fails.
+ *
+ * @ts must be uninitialized or already passed to tlsf_thread_destroy(). This
+ * call memsets @ts, so invoking it over live locks leaks them and is undefined.
  *
  * @ts : Thread-safe allocator instance
- * @mem : Memory region
+ * @mem : Memory region, which the caller continues to own
  * @bytes : Size of the memory region
  *
- * Return Total usable bytes across all arenas, or 0 on failure
+ * Return Total usable bytes across all arenas, or 0 if @ts or @mem is NULL,
+ * @bytes is 0, a lock cannot be created, or an arena pool cannot be built
  */
 size_t tlsf_thread_init(tlsf_thread_t *ts, void *mem, size_t bytes);
 
 /**
- * Destroy: release lock resources. Does not free the memory region passed to
- * tlsf_thread_init (caller retains ownership).
+ * Release the lock resources. The memory region given to tlsf_thread_init() is
+ * not freed; the caller still owns it.
+ *
+ * A NULL @ts is a no-op. Requires a quiescent instance. Afterwards the live
+ * arena count is zero, so every allocation fails until @ts is initialized
+ * again, and a second destroy does nothing.
  */
 void tlsf_thread_destroy(tlsf_thread_t *ts);
 
 /**
  * Thread-safe malloc. Tries the calling thread's preferred arena first, then
- * falls back to other arenas via non-blocking try-lock, then blocking acquire.
+ * the others by non-blocking try-lock, then by blocking acquire. Because memory
+ * is partitioned, this returns NULL only when no arena can satisfy @size, even
+ * if the free bytes summed across arenas would have been enough.
+ *
+ * A NULL @ts returns NULL.
  */
 void *tlsf_thread_malloc(tlsf_thread_t *ts, size_t size);
 
 /**
- * Thread-safe aligned allocation.
+ * Thread-safe aligned allocation. @align must be a non-zero power of two;
+ * anything else returns NULL, as does a NULL @ts. Arena search matches
+ * tlsf_thread_malloc().
  */
 void *tlsf_thread_aalloc(tlsf_thread_t *ts, size_t align, size_t size);
 
 /**
- * Thread-safe realloc. Attempts in-place realloc within the owning arena first;
- * falls back to cross-arena malloc + memcpy + free.
+ * Thread-safe realloc. Tries to resize inside the owning arena, then falls back
+ * to allocating elsewhere, copying, and freeing the original.
+ *
+ * A NULL @ptr allocates, and a zero @size frees @ptr and returns NULL. A @ptr
+ * outside every arena range returns NULL and frees nothing. As with
+ * tlsf_realloc(), a failure leaves @ptr allocated and intact, and the returned
+ * pointer need not equal @ptr.
  */
 void *tlsf_thread_realloc(tlsf_thread_t *ts, void *ptr, size_t size);
 
 /**
- * Thread-safe free. Finds the owning arena automatically via pointer-range
- * lookup (O(TLSF_ARENA_COUNT), effectively O(1)).
+ * Thread-safe free. Locates the owning arena by scanning the arena address
+ * ranges, which is linear in the live arena count and so effectively constant
+ * for the small counts this is meant for.
+ *
+ * A NULL @ts or @ptr is a no-op, and a @ptr outside every arena range is
+ * ignored. A @ptr that falls inside a range but is not a live allocation is
+ * undefined exactly as in tlsf_free(): the range check establishes ownership,
+ * not validity.
  */
 void tlsf_thread_free(tlsf_thread_t *ts, void *ptr);
 
@@ -287,17 +331,24 @@ void tlsf_thread_check(tlsf_thread_t *ts);
 
 /**
  * Aggregate statistics across all arenas. largest_free reports the single
- * largest free block in any arena.
+ * largest free block in any one arena, which is the largest allocation that can
+ * still succeed, not the sum of free space.
  *
  * Not an atomic snapshot: arena locks are taken one at a time, so concurrent
  * allocations in an already-visited arena are not reflected. Quiesce the other
  * threads first if you need an exact figure.
+ *
+ * Return 0 on success, -1 if @ts or @stats is NULL or if any arena fails
  */
 int tlsf_thread_stats(tlsf_thread_t *ts, tlsf_stats_t *stats);
 
 /**
- * Reset all arenas to initial state (bounded time). All outstanding pointers
- * become invalid.
+ * Reset every arena to its initial state in bounded time, discarding all
+ * allocations at once.
+ *
+ * A NULL @ts is a no-op. Each arena lock is taken in turn, but that does not
+ * make this safe against concurrent use: every pointer handed out so far
+ * becomes invalid, so the other threads must already be quiescent.
  */
 void tlsf_thread_reset(tlsf_thread_t *ts);
 

--- a/include/tlsf_thread.h
+++ b/include/tlsf_thread.h
@@ -113,7 +113,7 @@ extern "C" {
 #elif defined(__GNUC__) && (__GNUC__ >= 8) && \
     (defined(__MINGW32__) || defined(__MINGW64__))
 #define TLSF_THREAD_WIN_SRWLOCK
-#elif
+#else
 #define TLSF_THREAD_WIN_CRSECTION
 #endif
 #endif

--- a/src/tlsf.c
+++ b/src/tlsf.c
@@ -763,6 +763,25 @@ INLINE void mapping(size_t size, uint32_t *fl, uint32_t *sl)
     ASSERT(*sl < SL_COUNT, "wrong second level");
 }
 
+/* The preconditions below mirror the runtime asserts and are what discharge the
+ * shift and array-index obligations on 't->sl[*fl]' and '~0U << *sl'.
+ *
+ * Deliberately kept out of WP_FUNCTIONS: 35 of 36 goals prove, and the last one
+ * is the bitmap_ffs precondition on line 'sl_map = t->sl[*fl]'. Proving it
+ * needs the coherence invariant "a set bit in t->fl implies a nonzero
+ * t->sl[i]", which in turn needs a postcondition relating bitmap_ffs to the bit
+ * it found. bitmap_ffs is __builtin_ctz here, and Alt-Ergo does not discharge
+ * that bit-level link. Add this function to WP_FUNCTIONS only together with
+ * that invariant.
+ */
+/*@
+  requires \valid(t);
+  requires \valid(fl) && \valid(sl);
+  requires \separated(fl, sl);
+  requires *fl < FL_COUNT;
+  requires *sl < SL_COUNT;
+  assigns *fl, *sl;
+*/
 INLINE tlsf_block_t *block_find_suitable(tlsf_t *t, uint32_t *fl, uint32_t *sl)
 {
     ASSERT(*fl < FL_COUNT, "wrong first level");
@@ -830,6 +849,18 @@ INLINE void free_list_unlink(tlsf_block_t *prev, tlsf_block_t *next)
 /* Remove a free block from the free list. Unconditional writes: prev/next may
  * be &t->block_null (sentinel), in which case the writes are harmless.
  */
+/*@
+  requires \valid(t);
+  requires \valid(block);
+  requires fl < FL_COUNT;
+  requires sl < SL_COUNT;
+  requires \valid(block->prev_free);
+  requires \valid(block->next_free);
+  requires block->prev_free == block->next_free ||
+          \separated(block->prev_free, block->next_free);
+  assigns block->prev_free->next_free, block->next_free->prev_free;
+  assigns t->block[fl][sl], t->sl[fl], t->fl;
+*/
 INLINE void remove_free_block(tlsf_t *t,
                               tlsf_block_t *block,
                               uint32_t fl,
@@ -883,6 +914,18 @@ INLINE void free_list_link(tlsf_block_t *block,
  * Unconditional write: current may be &t->block_null (sentinel), in which case
  * the write to current->prev_free is harmless.
  */
+/*@
+  requires \valid(t);
+  requires \valid(block);
+  requires fl < FL_COUNT;
+  requires sl < SL_COUNT;
+  requires \valid(t->block[fl][sl]);
+  requires \separated(block, t->block[fl][sl]);
+  requires \separated(block, &t->block_null);
+  assigns block->next_free, block->prev_free;
+  assigns t->block[fl][sl]->prev_free;
+  assigns t->block[fl][sl], t->fl, t->sl[fl];
+*/
 INLINE void insert_free_block(tlsf_t *t,
                               tlsf_block_t *block,
                               uint32_t fl,

--- a/src/tlsf.c
+++ b/src/tlsf.c
@@ -1531,20 +1531,10 @@ size_t tlsf_pool_init(tlsf_t *t, void *mem, size_t bytes)
     if (!t || !mem)
         return 0;
 
-    /* Clear any stale ASan shadow in the provided memory. */
-    ASAN_UNPOISON(mem, bytes);
-
-    /* Zero-initialize the control structure, then point every bin at the
-     * sentinel so that free-list insert/remove can write unconditionally.
-     */
-    memset(t, 0, sizeof(*t));
-    bins_reset(t);
-
-    /* Align pool start */
-    char *start = align_ptr((char *) mem, ALIGN_SIZE);
-    size_t adj = (size_t) (start - (char *) mem);
+    size_t adj = align_offset((char *) mem, ALIGN_SIZE);
     if (bytes <= adj)
         return 0;
+    char *start = (char *) mem + adj;
 
     /* Compute usable pool size (aligned down) */
     size_t pool_bytes = (bytes - adj) & ~(ALIGN_SIZE - 1);
@@ -1555,6 +1545,18 @@ size_t tlsf_pool_init(tlsf_t *t, void *mem, size_t bytes)
     free_size &= ~(ALIGN_SIZE - 1);
     if (free_size < BLOCK_SIZE_MIN || free_size > BLOCK_SIZE_MAX)
         return 0;
+
+    /* Clear any stale ASan shadow in the provided memory. Deferred until every
+     * argument check has passed so a rejected re-init leaves the poisoning of
+     * an existing arena, and with it use-after-free detection, intact.
+     */
+    ASAN_UNPOISON(mem, bytes);
+
+    /* Zero-initialize the control structure, then point every bin at the
+     * sentinel so that free-list insert/remove can write unconditionally.
+     */
+    memset(t, 0, sizeof(*t));
+    bins_reset(t);
 
     /* Mark as a fixed-size, caller-owned pool */
     t->fixed = true;

--- a/src/tlsf.c
+++ b/src/tlsf.c
@@ -721,7 +721,7 @@ INLINE size_t round_block_size(size_t size)
  */
 /*@
   requires size > 0;
-  requires size <= TLSF_MAX_SIZE;
+  requires size < ((size_t) 1 << FL_MAX);
   requires \valid(fl);
   requires \valid(sl);
   requires \separated(fl, sl);

--- a/src/tlsf.c
+++ b/src/tlsf.c
@@ -434,24 +434,41 @@ INLINE size_t align_up(size_t x, size_t align)
     return (((x - 1) | (align - 1)) + 1);
 }
 
+/* Bytes that must be added to 'p' to reach the next 'align' boundary.
+ *
+ * Callers that cannot yet prove the boundary lies inside their buffer need this
+ * offset on its own: forming the aligned pointer first would run past the end
+ * of an undersized object before the bounds check can reject it.
+ *
+ * Note: uintptr_t is the canonical type for pointer-to-integer round-trips.
+ */
+/*@
+  requires align > 0;
+  requires (align & (align - 1)) == 0;
+  assigns \nothing;
+*/
+INLINE size_t align_offset(const char *p, size_t align)
+{
+    ASSERT(align, "alignment must be non-zero");
+    ASSERT(!(align & (align - 1)), "must align to a power of two");
+    return (size_t) (-(uintptr_t) p) & (align - 1);
+}
+
 /* Align pointer while preserving pointer provenance.
  *
  * The naive approach '(char *) align_up((size_t) p, align)' loses provenance
  * because the integer-to-pointer cast creates a pointer with no derivation
  * history. This causes issues with Miri, UBSan, and strict aliasing analysis.
- *
- * Instead, we compute the alignment offset and use pointer arithmetic:
- *   p + (aligned_addr - addr)
- * This preserves provenance because the result is derived from 'p'.
- *
- * Note: uintptr_t is the canonical type for pointer-to-integer round-trips.
+ * Adding the offset to 'p' keeps the result derived from 'p'.
  */
-/*@ assigns \result \from p, align; */
+/*@
+  requires align > 0;
+  requires (align & (align - 1)) == 0;
+  assigns \result \from p, align;
+*/
 INLINE char *align_ptr(char *p, size_t align)
 {
-    uintptr_t addr = (uintptr_t) p;
-    uintptr_t aligned_addr = align_up(addr, align);
-    return p + (aligned_addr - addr);
+    return p + align_offset(p, align);
 }
 
 /*@ assigns \result \from block; */

--- a/src/tlsf.c
+++ b/src/tlsf.c
@@ -1156,7 +1156,8 @@ static bool arena_grow(tlsf_t *t, size_t size)
 
 static size_t arena_append_pool(tlsf_t *t, void *mem, size_t size)
 {
-    if (!t->size || !mem || size < 2 * BLOCK_OVERHEAD)
+    if (!t->size || !mem || size < 2 * BLOCK_OVERHEAD ||
+        size >= (size_t) 1 << FL_MAX)
         return 0;
 
     /* Align memory block boundaries */
@@ -1193,11 +1194,13 @@ static size_t arena_append_pool(tlsf_t *t, void *mem, size_t size)
      * aligned_size for payload + BLOCK_OVERHEAD for new sentinel.
      */
     size_t old_size = t->size;
-    size_t new_total_size = t->size + aligned_size + BLOCK_OVERHEAD;
 
-    /* Reject if expanded pool would exceed the maximum addressable range. */
-    if (UNLIKELY(new_total_size > (size_t) 1 << FL_MAX))
+    /* Check before adding, so the total cannot wrap on 32-bit targets. */
+    if (UNLIKELY(t->size > ((size_t) 1 << FL_MAX) - BLOCK_OVERHEAD ||
+                 aligned_size >
+                     ((size_t) 1 << FL_MAX) - BLOCK_OVERHEAD - t->size))
         return 0;
+    size_t new_total_size = t->size + aligned_size + BLOCK_OVERHEAD;
 
     /* For dynamic pools, request the backend to extend. For fixed pools, the
      * caller provides adjacent memory directly.

--- a/src/tlsf.c
+++ b/src/tlsf.c
@@ -460,10 +460,18 @@ INLINE size_t align_offset(const char *p, size_t align)
  * because the integer-to-pointer cast creates a pointer with no derivation
  * history. This causes issues with Miri, UBSan, and strict aliasing analysis.
  * Adding the offset to 'p' keeps the result derived from 'p'.
+ *
+ * The caller must own a full alignment window at 'p'. Forming a pointer past
+ * the end of the object is undefined even when it is never dereferenced, and
+ * the boundary can sit up to 'align - 1' bytes ahead. A caller that cannot
+ * promise that window yet wants align_offset() instead, which yields the
+ * distance as a number so the span can be bounds-checked before any pointer is
+ * built. That is why tlsf_pool_init() uses align_offset().
  */
 /*@
   requires align > 0;
   requires (align & (align - 1)) == 0;
+  requires \valid_read((char *) p + (0 .. align - 1));
   assigns \result \from p, align;
 */
 INLINE char *align_ptr(char *p, size_t align)

--- a/tests/test.c
+++ b/tests/test.c
@@ -736,7 +736,16 @@ static void static_pool_test(void)
         void *p3 = tlsf_realloc(&t, p2, 50);
         assert(p3);
 
-        tlsf_free(&t, p3);
+        /* The two C-standard realloc aliases. Both are reachable through the
+         * core API, but until now only tests/test_thread.c drove them, so a
+         * build without the threading wrapper left them untested.
+         */
+        assert(tlsf_realloc(&t, p3, 0) == NULL);
+
+        void *p4 = tlsf_realloc(&t, NULL, 64);
+        assert(p4);
+
+        tlsf_free(&t, p4);
         tlsf_check(&t);
     }
     printf(".");

--- a/tests/test.c
+++ b/tests/test.c
@@ -816,9 +816,12 @@ static void static_pool_test(void)
         size_t aligned_usable = tlsf_pool_init(&ta, raw, 4096);
         assert(aligned_usable - usable == align);
 
-        /* A span shorter than the adjustment must be rejected. This pins the
-         * return contract, not the 'bytes <= adj' guard: drop that guard and
-         * the later BLOCK_SIZE_MAX check still rejects the underflowed span.
+        /* A span too short to reach the alignment boundary must be rejected.
+         * This pins the return contract, not the 'bytes <= adj' guard: drop
+         * that guard and this input still returns 0, because bytes == adj
+         * leaves pool_bytes at 0 and the lower-bound check rejects it. Only a
+         * strictly shorter span underflows far enough to reach the
+         * BLOCK_SIZE_MAX test.
          */
         tlsf_t tb;
         assert(tlsf_pool_init(&tb, raw + 1, align - 1) == 0);

--- a/tests/test.c
+++ b/tests/test.c
@@ -879,6 +879,11 @@ static void static_pool_test(void)
         size_t usable = tlsf_pool_init(&t, combined, half);
         assert(usable > 0);
 
+        /* Reject the impossible range before forming mem + size. */
+        assert(tlsf_append_pool(&t, combined + half, SIZE_MAX) == 0);
+        assert(tlsf_append_pool(&t, combined + half,
+                                (size_t) 1 << _TLSF_FL_MAX) == 0);
+
         void *p1 = tlsf_malloc(&t, 1000);
         assert(p1);
 

--- a/tests/test.c
+++ b/tests/test.c
@@ -773,7 +773,79 @@ static void static_pool_test(void)
     printf(".");
     fflush(stdout);
 
-    /* Test 7: Stats on static pool */
+    /* Test 7: An unaligned base is adjusted forward, not rejected. The
+     * adjustment is computed without forming the aligned pointer first, so
+     * confirm it still lands where align_ptr() would have put it.
+     */
+    {
+        const size_t align = sizeof(void *);
+
+        /* The union forces an aligned base. A bare char array is only
+         * incidentally aligned, and the size comparison below is exact only
+         * when 'raw' itself needs no adjustment.
+         */
+        static union {
+            void *alignment;
+            char bytes[4096 + sizeof(void *)];
+        } storage;
+        char *raw = storage.bytes;
+        char *unaligned = raw + 1;
+        tlsf_t t;
+        size_t usable = tlsf_pool_init(&t, unaligned, 4096);
+        assert(usable > 0);
+
+        void *p = tlsf_malloc(&t, 64);
+        assert(p);
+        assert((size_t) p % align == 0);
+        tlsf_check(&t);
+        tlsf_free(&t, p);
+
+        /* The same span from an aligned base loses exactly the one alignment
+         * step that the adjustment consumed.
+         */
+        tlsf_t ta;
+        size_t aligned_usable = tlsf_pool_init(&ta, raw, 4096);
+        assert(aligned_usable - usable == align);
+
+        /* A span shorter than the adjustment must be rejected. This pins the
+         * return contract, not the 'bytes <= adj' guard: drop that guard and
+         * the later BLOCK_SIZE_MAX check still rejects the underflowed span.
+         */
+        tlsf_t tb;
+        assert(tlsf_pool_init(&tb, raw + 1, align - 1) == 0);
+    }
+    printf(".");
+    fflush(stdout);
+
+    /* Test 8: A failed re-init must leave a live pool alone. */
+    {
+        static char pool[8192];
+        char tiny[8];
+        tlsf_t t;
+        assert(tlsf_pool_init(&t, pool, sizeof(pool)) > 0);
+
+        void *p = tlsf_malloc(&t, 512);
+        assert(p);
+        memset(p, 0xA5, 512);
+
+        tlsf_stats_t before;
+        assert(tlsf_get_stats(&t, &before) == 0);
+        assert(tlsf_pool_init(&t, tiny, sizeof(tiny)) == 0);
+
+        tlsf_stats_t after;
+        assert(tlsf_get_stats(&t, &after) == 0);
+        assert(after.total_used == before.total_used);
+        assert(after.total_free == before.total_free);
+        assert(after.block_count == before.block_count);
+        assert(((unsigned char *) p)[0] == 0xA5);
+
+        tlsf_free(&t, p);
+        tlsf_check(&t);
+    }
+    printf(".");
+    fflush(stdout);
+
+    /* Test 9: Stats on static pool */
     {
         static char pool[16384];
         tlsf_t t;
@@ -797,7 +869,7 @@ static void static_pool_test(void)
     printf(".");
     fflush(stdout);
 
-    /* Test 8: Append pool extends a static pool */
+    /* Test 10: Append pool extends a static pool */
     {
         static char combined[8192];
         tlsf_t t;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Makes allocator behavior safer and verifiable, and fixes a Windows build error. tlsf_pool_init now rejects invalid inputs without wiping a live pool, arena_append_pool is bounded to avoid 32‑bit overflows, and alignment/size contracts are precise and enforceable.

- Bug Fixes
  - tlsf_pool_init validates before memset; a failed re‑init leaves the existing arena and ASAN state intact.
  - arena_append_pool checks headroom before adding to prevent overflow and rejects sizes ≥ 2^FL_MAX to keep room for the sentinel.
  - Windows thread backend fallback compiles again by replacing a stray bare #elif with an else, re‑enabling the CRITICAL_SECTION path.
  - align_ptr now requires an alignment window and uses a new align_offset helper to avoid one‑past‑end pointers and potential uintptr_t wrap.
  - mapping’s bound is corrected to < 2^FL_MAX, matching implementation, and its contract is verified.

- Refactors
  - Added ACSL contracts for free‑list helpers and block_find_suitable, brought mapping under WP, and listed verification targets in the Makefile.
  - Expanded header docs: clarified TLSF_MAX_POOL_BITS limits, tlsf_append_pool adjacency/return rules, realloc/free behavior, thread‑hint and locking caveats (including the zero‑hint fallback), null‑argument semantics, and arena count guidance; parameter names and return docs now match behavior.

<sup>Written for commit e53bea4be0ebe45fb15399e7931bf30b5434d48a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/tlsf-bsd/pull/33?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

