### PR TITLE
Fix MSVC build and close the gaps it exposed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,13 +89,16 @@ jobs:
           - runner: ubuntu-24.04
             cc: gcc
             cflags: "-DTLSF_SPLIT_THRESHOLD=64"
-          # NDEBUG strips libc assert(). The test binaries undefine it
-          # themselves, so they keep reporting pass/fail; without that undef
-          # this row faults in the static pool test, which is the regression
-          # it exists to catch.
+          # Release configuration. NDEBUG covers libc assert(); clearing
+          # TLSF_DEBUG_FLAGS covers the library's own knobs, which are on for
+          # every other entry, so this is the only job that compiles the empty
+          # ASSERT(), the MAYBE_UNUSED machinery it needs, and the tlsf_check()
+          # stub. That is the build users ship. The test binaries undefine
+          # NDEBUG themselves, so they keep reporting pass/fail either way.
           - runner: ubuntu-24.04
             cc: gcc
             cflags: "-DNDEBUG"
+            make_args: "TLSF_DEBUG_FLAGS="
           # Portable bit-scan fallbacks used by toolchains without
           # __builtin_ctz / _BitScanForward. Unreachable on these runners
           # unless forced.
@@ -108,13 +111,13 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Build
-        run: make all
+        run: make all ${{ matrix.make_args }}
         env:
           CC: ${{ matrix.cc }}
           CXX: ${{ matrix.cc == 'clang' && 'clang++' || 'g++' }}
           CPPFLAGS: ${{ matrix.cflags }}
       - name: Test
-        run: make check
+        run: make check ${{ matrix.make_args }}
         env:
           CC: ${{ matrix.cc }}
           CXX: ${{ matrix.cc == 'clang' && 'clang++' || 'g++' }}
@@ -215,7 +218,7 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
       - name: Build (release, no assert/check overhead)
-        run: make all TLSF_DEBUG_FLAGS= CFLAGS="-Iinclude -std=gnu11 -O2 -Wall -Wextra -Wconversion"
+        run: make all TLSF_DEBUG_FLAGS=
       - name: WCET measurement
         run: ./build/wcet -i 5000 -w 500 -r build/wcet_raw.csv | tee build/wcet_output.txt
       - name: Generate plots

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,28 +164,28 @@ jobs:
       # build time.
       - name: Compile TLSF Core with MSVC
         run: |
-          cl.exe /c /Iinclude /O2 /W3 /std:c11 /DTLSF_ENABLE_ASSERT /DTLSF_ENABLE_CHECK src\tlsf.c /Fo:tlsf.obj
+          cl.exe /c /Iinclude /O2 /W3 /we4146 /std:c11 /DTLSF_ENABLE_ASSERT /DTLSF_ENABLE_CHECK src\tlsf.c /Fo:tlsf.obj
       - name: Compile Single-Threaded TLSF with MSVC
         run: |
-          cl.exe /Iinclude /O2 /W3 /std:c11 /DTLSF_ENABLE_ASSERT /DTLSF_ENABLE_CHECK tests\test.c tlsf.obj /Fe:test_tlsf.exe
+          cl.exe /Iinclude /O2 /W3 /we4146 /std:c11 /DTLSF_ENABLE_ASSERT /DTLSF_ENABLE_CHECK tests\test.c tlsf.obj /Fe:test_tlsf.exe
       - name: Run Single-Threaded Tests
         run: |
           .\test_tlsf.exe
       - name: Compile Multi-Threaded TLSF with MSVC (C11)
         run: |
-          cl.exe /Iinclude /O2 /W3 /std:c11 /DTLSF_ENABLE_ASSERT /DTLSF_ENABLE_CHECK /DTLSF_C11_THREADS src\tlsf_thread.c tests\test_thread.c tlsf.obj /Fe:test_thread.exe
+          cl.exe /Iinclude /O2 /W3 /we4146 /std:c11 /DTLSF_ENABLE_ASSERT /DTLSF_ENABLE_CHECK /DTLSF_C11_THREADS src\tlsf_thread.c tests\test_thread.c tlsf.obj /Fe:test_thread.exe
       - name: Run Multi-Threaded Tests
         run: |
           .\test_thread.exe
       - name: Compile Benchmark TLSF with MSVC
         run: |
-          cl.exe /Iinclude /O2 /W3 /std:c11 /DTLSF_ENABLE_ASSERT /DTLSF_ENABLE_CHECK tests\bench.c tlsf.obj /Fe:bench_tlsf.exe /link Psapi.lib
+          cl.exe /Iinclude /O2 /W3 /we4146 /std:c11 /DTLSF_ENABLE_ASSERT /DTLSF_ENABLE_CHECK tests\bench.c tlsf.obj /Fe:bench_tlsf.exe /link Psapi.lib
       - name: Run Benchmark TLSF
         run: |
           .\bench_tlsf.exe -l 10000 -i 3 -w 1
       - name: Compile WCET TLSF with MSVC
         run: |
-          cl.exe /Iinclude /O2 /W3 /std:c11 /DTLSF_ENABLE_ASSERT /DTLSF_ENABLE_CHECK tests\wcet.c tlsf.obj /Fe:wcet_tlsf.exe
+          cl.exe /Iinclude /O2 /W3 /we4146 /std:c11 /DTLSF_ENABLE_ASSERT /DTLSF_ENABLE_CHECK tests\wcet.c tlsf.obj /Fe:wcet_tlsf.exe
       - name: Run WCET TLSF
         run: |
           .\wcet_tlsf.exe -i 100 -w 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,28 +171,28 @@ jobs:
       # build time.
       - name: Compile TLSF Core with MSVC
         run: |
-          cl.exe /c /Iinclude /O2 /W3 /we4146 /std:c11 /DTLSF_ENABLE_ASSERT /DTLSF_ENABLE_CHECK src\tlsf.c /Fo:tlsf.obj
+          cl.exe /c /Iinclude /O2 /W3 /we4146 /we4334 /std:c11 /DTLSF_ENABLE_ASSERT /DTLSF_ENABLE_CHECK src\tlsf.c /Fo:tlsf.obj
       - name: Compile Single-Threaded TLSF with MSVC
         run: |
-          cl.exe /Iinclude /O2 /W3 /we4146 /std:c11 /DTLSF_ENABLE_ASSERT /DTLSF_ENABLE_CHECK tests\test.c tlsf.obj /Fe:test_tlsf.exe
+          cl.exe /Iinclude /O2 /W3 /we4146 /we4334 /std:c11 /DTLSF_ENABLE_ASSERT /DTLSF_ENABLE_CHECK tests\test.c tlsf.obj /Fe:test_tlsf.exe
       - name: Run Single-Threaded Tests
         run: |
           .\test_tlsf.exe
       - name: Compile Multi-Threaded TLSF with MSVC (C11)
         run: |
-          cl.exe /Iinclude /O2 /W3 /we4146 /std:c11 /DTLSF_ENABLE_ASSERT /DTLSF_ENABLE_CHECK /DTLSF_C11_THREADS src\tlsf_thread.c tests\test_thread.c tlsf.obj /Fe:test_thread.exe
+          cl.exe /Iinclude /O2 /W3 /we4146 /we4334 /std:c11 /DTLSF_ENABLE_ASSERT /DTLSF_ENABLE_CHECK /DTLSF_C11_THREADS src\tlsf_thread.c tests\test_thread.c tlsf.obj /Fe:test_thread.exe
       - name: Run Multi-Threaded Tests
         run: |
           .\test_thread.exe
       - name: Compile Benchmark TLSF with MSVC
         run: |
-          cl.exe /Iinclude /O2 /W3 /we4146 /std:c11 /DTLSF_ENABLE_ASSERT /DTLSF_ENABLE_CHECK tests\bench.c tlsf.obj /Fe:bench_tlsf.exe /link Psapi.lib
+          cl.exe /Iinclude /O2 /W3 /we4146 /we4334 /std:c11 /DTLSF_ENABLE_ASSERT /DTLSF_ENABLE_CHECK tests\bench.c tlsf.obj /Fe:bench_tlsf.exe /link Psapi.lib
       - name: Run Benchmark TLSF
         run: |
           .\bench_tlsf.exe -l 10000 -i 3 -w 1
       - name: Compile WCET TLSF with MSVC
         run: |
-          cl.exe /Iinclude /O2 /W3 /we4146 /std:c11 /DTLSF_ENABLE_ASSERT /DTLSF_ENABLE_CHECK tests\wcet.c tlsf.obj /Fe:wcet_tlsf.exe
+          cl.exe /Iinclude /O2 /W3 /we4146 /we4334 /std:c11 /DTLSF_ENABLE_ASSERT /DTLSF_ENABLE_CHECK tests\wcet.c tlsf.obj /Fe:wcet_tlsf.exe
       - name: Run WCET TLSF
         run: |
           .\wcet_tlsf.exe -i 100 -w 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,13 @@ jobs:
           - runner: ubuntu-24.04
             cc: gcc
             cflags: "-DTLSF_SPLIT_THRESHOLD=64"
+          # NDEBUG strips libc assert(). The test binaries undefine it
+          # themselves, so they keep reporting pass/fail; without that undef
+          # this row faults in the static pool test, which is the regression
+          # it exists to catch.
+          - runner: ubuntu-24.04
+            cc: gcc
+            cflags: "-DNDEBUG"
           # Portable bit-scan fallbacks used by toolchains without
           # __builtin_ctz / _BitScanForward. Unreachable on these runners
           # unless forced.

--- a/Makefile
+++ b/Makefile
@@ -90,31 +90,61 @@ THREAD_OBJS = $(OUT)/tlsf_thread.o
 deps := $(OBJS:%.o=%.o.d) $(THREAD_OBJS:%.o=%.o.d) \
 	$(OUT)/bench.d $(OUT)/wcet.d $(THREAD_TARGETS:%=%.d) $(CPP_TARGETS:%=%.d)
 
-$(OUT)/test: $(OBJS) tests/test.c
-	$(CC) $(CPPFLAGS) $(CFLAGS) -o $@ $^ $(LDFLAGS)
+# Make compares timestamps, not command lines, so flipping a variable on the
+# command line rebuilds nothing. 'make check TLSF_DEBUG_FLAGS=' on an
+# already-built tree would relink against the assertions-enabled objects and
+# report a pass for a configuration it never compiled. Stamping the toolchain
+# and flags, and depending on the stamp, makes any change rebuild. The stamp is
+# rewritten only when the value differs, so a no-op build stays a no-op.
+#
+# The value covers every variable the compile and link recipes expand;
+# -pthread and -lm are literals. One stamp covers all of them, so an
+# LDFLAGS-only change also recompiles the two objects. Rebuilding more than
+# strictly needed is safe, and a second stamp is not worth the machinery here.
+FLAGS_STAMP := $(OUT)/.build-flags
+BUILD_FLAGS := $(CC) $(CXX) $(CPPFLAGS) $(CFLAGS) $(CXXFLAGS) $(LDFLAGS)
 
-$(OUT)/bench: $(OBJS) tests/bench.c
+# Exported rather than pasted into the recipe text. A flag value may contain a
+# quote, and interpolating one into a quoted shell word would end the string
+# early and kill the recipe on a syntax error. A parameter expansion is not
+# rescanned, so the value survives whatever it holds. Not $(file), which does no
+# shell quoting at all, because it needs make 4.0 and this tree builds on 3.81.
+export BUILD_FLAGS
+FORCE:
+$(FLAGS_STAMP): FORCE
+	@mkdir -p $(OUT)
+	@printf '%s\n' "$$BUILD_FLAGS" | cmp -s - $@ || \
+		printf '%s\n' "$$BUILD_FLAGS" > $@
+
+# The link rules below spell out their sources instead of using $^. The dep
+# files pull headers in as prerequisites, and $(FLAGS_STAMP) is one too, so $^
+# would hand both to the compiler as source files.
+$(OUT)/test: $(OBJS) tests/test.c $(FLAGS_STAMP)
+	$(CC) $(CPPFLAGS) $(CFLAGS) -o $@ $(OBJS) tests/test.c $(LDFLAGS)
+
+$(OUT)/bench: $(OBJS) tests/bench.c $(FLAGS_STAMP)
 	$(CC) $(CPPFLAGS) $(CFLAGS) -o $@ -MMD -MF $@.d $(OBJS) tests/bench.c \
 		$(LDFLAGS) -lm
 
-$(OUT)/wcet: $(OBJS) tests/wcet.c
+$(OUT)/wcet: $(OBJS) tests/wcet.c $(FLAGS_STAMP)
 	$(CC) $(CPPFLAGS) $(CFLAGS) -o $@ -MMD -MF $@.d $(OBJS) tests/wcet.c \
 		$(LDFLAGS) -lm
 
 # Thread-safe module (requires pthreads)
-$(OUT)/tlsf_thread.o: src/tlsf_thread.c include/tlsf_thread.h
+$(OUT)/tlsf_thread.o: src/tlsf_thread.c include/tlsf_thread.h $(FLAGS_STAMP)
 	@mkdir -p $(OUT)
 	$(CC) $(CPPFLAGS) $(CFLAGS) -pthread -c -o $@ -MMD -MF $@.d $<
 
-$(OUT)/test_thread: $(OBJS) $(THREAD_OBJS) tests/test_thread.c
+$(OUT)/test_thread: $(OBJS) $(THREAD_OBJS) tests/test_thread.c \
+		$(FLAGS_STAMP)
 	$(CC) $(CPPFLAGS) $(CFLAGS) -pthread -o $@ -MMD -MF $@.d $(OBJS) \
 		$(THREAD_OBJS) tests/test_thread.c $(LDFLAGS)
 
-$(OUT)/test_cpp: $(OBJS) $(THREAD_OBJS) tests/test_cpp.cpp
+$(OUT)/test_cpp: $(OBJS) $(THREAD_OBJS) tests/test_cpp.cpp $(FLAGS_STAMP)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -pthread -o $@ -MMD -MF $@.d $(OBJS) \
 		$(THREAD_OBJS) tests/test_cpp.cpp $(LDFLAGS)
 
-$(OUT)/%.o: src/%.c
+$(OUT)/%.o: src/%.c $(FLAGS_STAMP)
 	@mkdir -p $(OUT)
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c -o $@ -MMD -MF $@.d $<
 
@@ -168,11 +198,11 @@ wcet-plot: all
 
 clean:
 	$(RM) $(TARGETS) $(THREAD_TARGETS) $(CPP_TARGETS)
-	$(RM) $(OBJS) $(THREAD_OBJS) $(deps)
+	$(RM) $(OBJS) $(THREAD_OBJS) $(deps) $(FLAGS_STAMP)
 	$(RM) $(OUT)/wcet_raw.csv $(OUT)/wcet_summary.csv
 	$(RM) $(OUT)/wcet_boxplot.png $(OUT)/wcet_histogram.png
 	$(RM) -r $(OUT)/*.dSYM
 
-.PHONY: all check clean verify bench bench-quick wcet wcet-quick wcet-plot
+.PHONY: all check clean verify bench bench-quick wcet wcet-quick wcet-plot FORCE
 
 -include $(deps)

--- a/src/tlsf.c
+++ b/src/tlsf.c
@@ -449,6 +449,12 @@ INLINE void block_set_prev_free(tlsf_block_t *block, bool free)
                     (free ? BLOCK_BIT_PREV_FREE : 0);
 }
 
+/* The two requires mirror the runtime assertions below, and match
+ * align_offset() and align_ptr() byte for byte. Keep them written out: folding
+ * the pair into a named predicate stops Alt-Ergo discharging them at the call
+ * sites. Without them WP cannot prove this function's own assertions in an
+ * assertions-enabled build.
+ */
 /*@
   requires align > 0;
   requires (align & (align - 1)) == 0;
@@ -573,7 +579,12 @@ INLINE tlsf_block_t *block_prev(const tlsf_block_t *block)
     return block->prev;
 }
 
-/* Return location of next existing block. */
+/* Return location of next existing block. The third clause restates the second
+ * conjunct of tlsf_next_header_span, and the second clause restates the first,
+ * so neither asks anything new of a caller. Both are load-bearing anyway:
+ * without them Alt-Ergo crashes on this function's runtime assertion with
+ * "unbound variable in of_term" rather than merely timing out.
+ */
 /*@
   requires tlsf_next_header_span(block);
   requires tlsf_aligned_header(block);

--- a/src/tlsf.c
+++ b/src/tlsf.c
@@ -180,7 +180,11 @@ TLSF_STATIC_ASSERT(sizeof(size_t) == sizeof(void *),
                    "size_t must equal pointer size");
 TLSF_STATIC_ASSERT(offsetof(tlsf_block_t, header) == BLOCK_HEADER_OFFSET,
                    "unexpected block header offset");
-TLSF_STATIC_ASSERT(ALIGN_SIZE == BLOCK_SIZE_SMALL / SL_COUNT,
+/* SL_COUNT is cast because it is an unsigned int and BLOCK_SIZE_SMALL is a
+ * size_t: without it the division widens a 32-bit shift result to 64 bits,
+ * which is what MSVC reports as C4334, and CI promotes that to an error.
+ */
+TLSF_STATIC_ASSERT(ALIGN_SIZE == BLOCK_SIZE_SMALL / (size_t) SL_COUNT,
                    "sizes are not properly set");
 TLSF_STATIC_ASSERT(BLOCK_SIZE_MIN < BLOCK_SIZE_SMALL,
                    "min allocation size is wrong");

--- a/src/tlsf.c
+++ b/src/tlsf.c
@@ -1696,14 +1696,176 @@ void tlsf_pool_reset(tlsf_t *t)
         }                                                         \
     } while (0)
 
-/**
- * Comprehensive heap consistency check.
+/* Phase 1: walk every block from the pool start to the sentinel, validating the
+ * physical chain.
  *
- * Validates ALL block invariants by walking the entire heap:
- * 1. Block walk validation (all blocks from pool start to sentinel)
- * 2. Free list validation (bitmap consistency, coalescing, cycle/duplicate
- *    detection via Floyd's algorithm -- O(1) stack usage)
- * 3. Cross-validation (free list count matches block walk count)
+ * Returns the number of free blocks seen, which phase 3 reconciles against the
+ * free lists.
+ */
+static size_t check_block_chain(tlsf_t *t)
+{
+    CHECK(t->arena, "failed to get arena pointer");
+    CHECK((size_t) t->arena % ALIGN_SIZE == 0, "arena not aligned");
+
+    /* The first block sits at t->arena - BLOCK_OVERHEAD: tlsf_block_t's prev
+     * field precedes the header, and for the first block that field is outside
+     * the arena and never accessed.
+     */
+    tlsf_block_t *block = to_block((char *) t->arena - BLOCK_OVERHEAD);
+    tlsf_block_t *prev_block = NULL;
+    size_t walk_free_count = 0;
+    size_t total_size = 0;
+    bool prev_was_free = false;
+
+    while (block_size(block) != 0) {
+        size_t bsize = block_size(block);
+
+        CHECK(bsize >= BLOCK_SIZE_MIN, "block smaller than minimum size");
+        CHECK(bsize < (size_t) 1 << FL_MAX, "block exceeds mapping range");
+        CHECK(bsize % ALIGN_SIZE == 0, "block size not aligned");
+        CHECK((size_t) block % ALIGN_SIZE == 0, "block pointer not aligned");
+        CHECK((size_t) block_payload(block) % ALIGN_SIZE == 0,
+              "payload not aligned");
+
+        if (prev_block) {
+            CHECK(block_is_prev_free(block) == prev_was_free,
+                  "prev_free bit mismatch with actual previous block state");
+            if (prev_was_free)
+                CHECK(block->prev == prev_block,
+                      "prev pointer doesn't match previous block");
+        }
+
+        if (block_is_free(block)) {
+            walk_free_count++;
+
+            /* Coalescing invariant: no two consecutive free blocks. Free-list
+             * membership is verified by the phase 2/3 count match.
+             */
+            CHECK(!prev_was_free,
+                  "consecutive free blocks (coalescing failed)");
+        }
+        prev_was_free = block_is_free(block);
+
+        total_size += bsize + BLOCK_OVERHEAD;
+        prev_block = block;
+        block = block_next(block);
+    }
+
+    /* The loop above exits only at a zero-size block, so the sentinel's size
+     * needs no separate check; what it carries in its flags does.
+     */
+    CHECK(!block_is_free(block), "sentinel marked as free");
+    CHECK(block_is_prev_free(block) == prev_was_free,
+          "sentinel prev_free bit mismatch");
+    if (prev_was_free)
+        CHECK(block->prev == prev_block, "sentinel prev pointer incorrect");
+
+    total_size += BLOCK_OVERHEAD;
+    CHECK(total_size == t->size, "block sizes don't sum to pool size");
+
+    return walk_free_count;
+}
+
+/* Walk one non-empty bin's free list, validating every block in it and the
+ * links between them.
+ *
+ * Floyd's cycle detection runs alongside: a fast pointer advances two steps per
+ * iteration, so a duplicate block that closes the list into a cycle makes slow
+ * and fast collide within O(n) steps. This replaces a former 16 KB hash-table
+ * approach with O(1) stack usage, which matters on embedded and RTOS targets.
+ *
+ * Cross-bin duplicates need no separate pass: every block is checked to map to
+ * the bin holding it, so one cannot sit in two bins without failing that check.
+ */
+static size_t check_bin_list(tlsf_t *t, uint32_t fl_idx, uint32_t sl_idx)
+{
+    tlsf_block_t *list_block = t->block[fl_idx][sl_idx];
+    const tlsf_block_t *list_prev = &t->block_null;
+    const tlsf_block_t *fast = list_block;
+    size_t count = 0;
+
+    while (list_block != &t->block_null) {
+        count++;
+
+        CHECK(block_is_free(list_block), "block in free list not free");
+
+        uint32_t fl, sl;
+        mapping(block_size(list_block), &fl, &sl);
+        CHECK(fl == fl_idx && sl == sl_idx, "block in wrong FL/SL bin");
+
+        CHECK(block_size(list_block) >= BLOCK_SIZE_MIN,
+              "free block below minimum size");
+
+        /* Coalescing: neither physical neighbor may be free. */
+        CHECK(!block_is_prev_free(list_block),
+              "free block has free predecessor (coalescing violated)");
+        tlsf_block_t *next_phys = block_next(list_block);
+        CHECK(!block_is_free(next_phys),
+              "free block has free successor (coalescing violated)");
+        CHECK(block_is_prev_free(next_phys),
+              "next block doesn't know this block is free");
+
+        CHECK(list_block->prev_free == list_prev,
+              "free list prev pointer incorrect");
+        if (list_prev != &t->block_null)
+            CHECK(list_prev->next_free == list_block,
+                  "free list next pointer incorrect");
+
+        list_prev = list_block;
+        list_block = list_block->next_free;
+
+        if (fast != &t->block_null)
+            fast = fast->next_free;
+        if (fast != &t->block_null)
+            fast = fast->next_free;
+        CHECK(list_block == &t->block_null || list_block != fast,
+              "cycle in free list (duplicate block / double-free?)");
+    }
+
+    return count;
+}
+
+/* Phase 2: every bin agrees with the bitmaps, and every list it holds is
+ * internally consistent.
+ *
+ * Returns the total number of blocks on the free lists.
+ */
+static size_t check_free_lists(tlsf_t *t)
+{
+    size_t list_free_count = 0;
+
+    for (uint32_t i = 0; i < FL_COUNT; ++i) {
+        uint32_t sl_list = t->sl[i];
+
+        if (!(t->fl & (1U << i))) {
+            CHECK(sl_list == 0, "SL bitmap non-zero but FL bit is clear");
+            for (uint32_t j = 0; j < SL_COUNT; ++j)
+                CHECK(t->block[i][j] == &t->block_null,
+                      "block pointer not sentinel but FL bit is clear");
+            continue;
+        }
+
+        CHECK(sl_list != 0, "FL bit set but SL bitmap is empty");
+
+        for (uint32_t j = 0; j < SL_COUNT; ++j) {
+            if (!(sl_list & (1U << j))) {
+                CHECK(t->block[i][j] == &t->block_null,
+                      "block pointer not sentinel but SL bit is clear");
+                continue;
+            }
+
+            CHECK(t->block[i][j] != &t->block_null,
+                  "SL bit set but block list is empty (sentinel)");
+            list_free_count += check_bin_list(t, i, j);
+        }
+    }
+
+    return list_free_count;
+}
+
+/* Walk the whole arena and abort if any invariant is broken, in three phases:
+ * check_block_chain() for the physical chain, check_free_lists() for the bins,
+ * then the count reconciliation below. Each is documented at its definition.
  */
 void tlsf_check(tlsf_t *t)
 {
@@ -1713,177 +1875,9 @@ void tlsf_check(tlsf_t *t)
     if (!t->size)
         return;
 
-    /* Get arena start */
-    void *arena_start = t->arena;
-    CHECK(arena_start, "failed to get arena pointer");
-    CHECK((size_t) arena_start % ALIGN_SIZE == 0, "arena not aligned");
+    size_t walk_free_count = check_block_chain(t);
+    size_t list_free_count = check_free_lists(t);
 
-    /* Phase 1: Walk ALL blocks from pool start to sentinel This validates the
-     * physical block chain integrity
-     *
-     * The first block is at arena_start - BLOCK_OVERHEAD because the
-     * tlsf_block_t structure's prev field precedes the header, but for the
-     * first block, the prev field is outside the arena (never accessed).
-     */
-    tlsf_block_t *block = to_block((char *) arena_start - BLOCK_OVERHEAD);
-    tlsf_block_t *prev_block = NULL;
-    size_t walk_free_count = 0;
-    size_t total_size = 0;
-    bool prev_was_free = false;
-
-    while (block_size(block) != 0) {
-        size_t bsize = block_size(block);
-
-        /* Size invariants */
-        CHECK(bsize >= BLOCK_SIZE_MIN, "block smaller than minimum size");
-        CHECK(bsize < (size_t) 1 << FL_MAX, "block exceeds mapping range");
-        CHECK(bsize % ALIGN_SIZE == 0, "block size not aligned");
-
-        /* Pointer alignment check */
-        CHECK((size_t) block % ALIGN_SIZE == 0, "block pointer not aligned");
-        CHECK((size_t) block_payload(block) % ALIGN_SIZE == 0,
-              "payload not aligned");
-
-        /* Prev pointer validation */
-        if (prev_block) {
-            CHECK(block_is_prev_free(block) == prev_was_free,
-                  "prev_free bit mismatch with actual previous block state");
-            if (prev_was_free) {
-                CHECK(block->prev == prev_block,
-                      "prev pointer doesn't match previous block");
-            }
-        }
-
-        if (block_is_free(block)) {
-            walk_free_count++;
-
-            /* Coalescing invariant: no two consecutive free blocks */
-            CHECK(!prev_was_free,
-                  "consecutive free blocks (coalescing failed)");
-
-            /* Free-list membership verified by Phase 2/3 count match */
-            prev_was_free = true;
-        } else {
-            prev_was_free = false;
-        }
-
-        total_size += bsize + BLOCK_OVERHEAD;
-        prev_block = block;
-        block = block_next(block);
-    }
-
-    /* Sentinel validation */
-    CHECK(block_size(block) == 0, "sentinel has non-zero size");
-    CHECK(!block_is_free(block), "sentinel marked as free");
-    CHECK(block_is_prev_free(block) == prev_was_free,
-          "sentinel prev_free bit mismatch");
-    if (prev_was_free && prev_block) {
-        CHECK(block->prev == prev_block, "sentinel prev pointer incorrect");
-    }
-
-    /* Account for sentinel header */
-    total_size += BLOCK_OVERHEAD;
-    CHECK(total_size == t->size, "block sizes don't sum to pool size");
-
-    /* Phase 2: Walk free lists and validate bitmap consistency */
-    size_t list_free_count = 0;
-
-    for (uint32_t i = 0; i < FL_COUNT; ++i) {
-        uint32_t fl_bit = t->fl & (1U << i);
-        uint32_t sl_list = t->sl[i];
-
-        /* If FL bit is clear, all SL bits and block pointers must be the
-         * sentinel.
-         */
-        if (!fl_bit) {
-            CHECK(sl_list == 0, "SL bitmap non-zero but FL bit is clear");
-            for (uint32_t j = 0; j < SL_COUNT; ++j) {
-                CHECK(t->block[i][j] == &t->block_null,
-                      "block pointer not sentinel but FL bit is clear");
-            }
-            continue;
-        }
-
-        /* FL bit is set, so at least one SL bit must be set */
-        CHECK(sl_list != 0, "FL bit set but SL bitmap is empty");
-
-        for (uint32_t j = 0; j < SL_COUNT; ++j) {
-            uint32_t sl_bit = sl_list & (1U << j);
-            tlsf_block_t *list_block = t->block[i][j];
-
-            if (!sl_bit) {
-                CHECK(list_block == &t->block_null,
-                      "block pointer not sentinel but SL bit is clear");
-                continue;
-            }
-
-            /* SL bit is set, so block list must be non-empty */
-            CHECK(list_block != &t->block_null,
-                  "SL bit set but block list is empty (sentinel)");
-
-            /* Walk the free list for this bin. Floyd's cycle detection runs in
-             * parallel: a fast pointer advances two steps per iteration. If a
-             * duplicate block creates a cycle, slow and fast will collide in
-             * O(n) steps. This replaces the former 16 KB hash-table approach
-             * with O(1) stack usage -- critical for embedded/RTOS targets.
-             *
-             * Cross-bin duplicates are already caught above: Phase 2 validates
-             * that each block maps to its bin, so a block cannot appear in two
-             * different bins without failing the fl/sl check first.
-             */
-            const tlsf_block_t *list_prev = &t->block_null;
-            const tlsf_block_t *fast = list_block;
-            while (list_block != &t->block_null) {
-                list_free_count++;
-
-                /* Block must be free */
-                CHECK(block_is_free(list_block), "block in free list not free");
-
-                /* Block must be in correct bin */
-                uint32_t fl, sl;
-                mapping(block_size(list_block), &fl, &sl);
-                CHECK(fl == i && sl == j, "block in wrong FL/SL bin");
-
-                /* Size constraints */
-                CHECK(block_size(list_block) >= BLOCK_SIZE_MIN,
-                      "free block below minimum size");
-
-                /* Coalescing: previous physical block must not be free */
-                CHECK(!block_is_prev_free(list_block),
-                      "free block has free predecessor (coalescing violated)");
-
-                /* Coalescing: next physical block must not be free */
-                tlsf_block_t *next_phys = block_next(list_block);
-                CHECK(!block_is_free(next_phys),
-                      "free block has free successor (coalescing violated)");
-
-                /* Next block must have prev_free set */
-                CHECK(block_is_prev_free(next_phys),
-                      "next block doesn't know this block is free");
-
-                /* Free list linkage */
-                CHECK(list_block->prev_free == list_prev,
-                      "free list prev pointer incorrect");
-                if (list_prev != &t->block_null) {
-                    CHECK(list_prev->next_free == list_block,
-                          "free list next pointer incorrect");
-                }
-
-                list_prev = list_block;
-                list_block = list_block->next_free;
-
-                /* Floyd's tortoise-and-hare cycle detection */
-                if (fast != &t->block_null)
-                    fast = fast->next_free;
-                if (fast != &t->block_null)
-                    fast = fast->next_free;
-                CHECK(list_block == &t->block_null || list_block != fast,
-                      "cycle in free list (duplicate block / double-free?)");
-            }
-        }
-    }
-
-    /* Phase 3: Cross-validation */
     CHECK(walk_free_count == list_free_count,
           "free block count mismatch between block walk and free list walk");
 }

--- a/src/tlsf.c
+++ b/src/tlsf.c
@@ -1092,6 +1092,58 @@ INLINE tlsf_block_t *block_ltrim_free(tlsf_t *t,
     return rest;
 }
 
+/* Would merging with a free predecessor make room for 'size'? A backward merge
+ * absorbs a free successor as well, so its bytes count too.
+ */
+INLINE bool block_can_expand_prev(tlsf_block_t *block, size_t size)
+{
+    if (!block_is_prev_free(block))
+        return false;
+
+    size_t room =
+        block_size(block_prev(block)) + block_size(block) + BLOCK_OVERHEAD;
+    tlsf_block_t *next = block_next(block);
+    if (block_is_free(next))
+        room += block_size(next) + BLOCK_OVERHEAD;
+    return size <= room;
+}
+
+/* Absorb 'block' into its free predecessor and slide the payload down, then
+ * absorb a free successor as well.
+ *
+ * Returns the merged block, which is used rather than free: the caller is
+ * growing a live allocation into it.
+ *
+ * The order is forced from both sides. Unlinking has to precede the move,
+ * because prev's free-list pointers sit at the front of the payload the move
+ * overwrites. The move has to precede the absorb, because absorbing writes the
+ * successor's prev field, which overlays the last word of block's payload.
+ *
+ * That is why this goes through block_absorb_at() rather than block_absorb():
+ * the move can bury block's own header under the relocated payload, so the
+ * successor has to be resolved up front and passed in rather than re-derived.
+ */
+INLINE tlsf_block_t *block_expand_prev(tlsf_t *t, tlsf_block_t *block)
+{
+    size_t avail = block_size(block);
+    tlsf_block_t *prev = block_prev(block);
+    tlsf_block_t *next = block_next(block);
+
+    block_remove(t, prev);
+    ASAN_UNPOISON(block_payload(prev), block_size(prev));
+    memmove(block_payload(prev), block_payload(block), avail);
+
+    prev = block_absorb_at(prev, next, avail + BLOCK_OVERHEAD);
+    prev = block_merge_next(t, prev);
+
+    /* prev carried the free bit in from the free list; clearing it here also
+     * updates the successor, so no separate block_set_prev_free() is needed.
+     */
+    block_set_free(prev, false);
+    ASAN_UNPOISON(block_payload(prev), block_size(prev));
+    return prev;
+}
+
 INLINE void *block_use(tlsf_t *t, tlsf_block_t *block, size_t size)
 {
     /* Unpoison before trimming -- block_split writes into the payload. */
@@ -1507,6 +1559,23 @@ size_t tlsf_usable_size(void *ptr)
     return block_size(block);
 }
 
+/* Move an allocation to a fresh block. On failure the original is untouched,
+ * which is what lets tlsf_realloc() return NULL without losing the payload.
+ *
+ * Not a block_* helper despite the shape: it calls tlsf_malloc()/tlsf_free(),
+ * so unlike everything in that family it depends on the layer above it and can
+ * never join the Frama-C leaf list.
+ */
+static void *realloc_relocate(tlsf_t *t, void *mem, size_t size)
+{
+    void *dst = tlsf_malloc(t, size);
+    if (!dst)
+        return NULL;
+    memcpy(dst, mem, block_size(block_from_payload(mem)));
+    tlsf_free(t, mem);
+    return dst;
+}
+
 void *tlsf_realloc(tlsf_t *t, void *mem, size_t size)
 {
     /* Zero-size requests are treated as free. */
@@ -1530,72 +1599,20 @@ void *tlsf_realloc(tlsf_t *t, void *mem, size_t size)
     /* Do we need to expand? */
     if (size > avail) {
         tlsf_block_t *next = block_next(block);
-        bool next_free = block_is_free(next);
-        size_t next_size = next_free ? block_size(next) + BLOCK_OVERHEAD : 0;
 
-        /* Try forward expansion first (no data movement required). */
-        if (next_free && size <= avail + next_size) {
+        /* Three ways to grow, in order of cost: forward costs nothing, backward
+         * costs a memmove, relocation costs a copy plus a new block.
+         */
+        if (block_is_free(next) &&
+            size <= avail + block_size(next) + BLOCK_OVERHEAD) {
             block_merge_next(t, block);
             ASAN_UNPOISON(block_payload(block), block_size(block));
             block_set_prev_free(block_next(block), false);
-        }
-        /* Try backward expansion (requires memmove). */
-        else if (block_is_prev_free(block)) {
-            tlsf_block_t *prev = block_prev(block);
-            size_t prev_size = block_size(prev);
-            size_t combined = prev_size + avail + BLOCK_OVERHEAD;
-
-            /* Can also merge with next if it's free. */
-            if (next_free)
-                combined += next_size;
-
-            if (size <= combined) {
-                /* Remove prev from free list. */
-                block_remove(t, prev);
-
-                ASAN_UNPOISON(block_payload(prev), prev_size);
-
-                /* Move data to prev's payload area (regions may overlap). */
-                memmove(block_payload(prev), mem, avail);
-
-                /* Merge prev + current: update size, preserve prev's prev_free
-                 * bit. Result is a used block (not free).
-                 */
-                size_t new_size = prev_size + avail + BLOCK_OVERHEAD;
-                prev->header = new_size | (prev->header & BLOCK_BIT_PREV_FREE);
-                block_link_next(prev);
-
-                /* Also merge next if it's free. */
-                if (next_free) {
-                    block_remove(t, next);
-                    ASAN_UNPOISON(block_payload(next), block_size(next));
-                    prev->header += block_size(next) + BLOCK_OVERHEAD;
-                    block_link_next(prev);
-                }
-
-                /* Update next block's prev_free status (we're now used). */
-                block_set_prev_free(block_next(prev), false);
-
-                /* Switch to the merged block. */
-                block = prev;
-                mem = block_payload(block);
-            } else {
-                /* Combined space still insufficient, must relocate. */
-                void *dst = tlsf_malloc(t, size);
-                if (dst) {
-                    memcpy(dst, mem, avail);
-                    tlsf_free(t, mem);
-                }
-                return dst;
-            }
+        } else if (block_can_expand_prev(block, size)) {
+            block = block_expand_prev(t, block);
+            mem = block_payload(block);
         } else {
-            /* No in-place expansion possible, must relocate. */
-            void *dst = tlsf_malloc(t, size);
-            if (dst) {
-                memcpy(dst, mem, avail);
-                tlsf_free(t, mem);
-            }
-            return dst;
+            return realloc_relocate(t, mem, size);
         }
     }
 

--- a/src/tlsf.c
+++ b/src/tlsf.c
@@ -464,6 +464,10 @@ INLINE size_t align_up(size_t x, size_t align)
  * of an undersized object before the bounds check can reject it.
  *
  * Note: uintptr_t is the canonical type for pointer-to-integer round-trips.
+ * 'align' is a power of two, so subtracting from it is congruent to negating
+ * modulo 'align' and the mask below discards the difference. Writing it that
+ * way also keeps unary minus off an unsigned operand, which MSVC reports as
+ * C4146.
  */
 /*@
   requires align > 0;
@@ -474,7 +478,7 @@ INLINE size_t align_offset(const char *p, size_t align)
 {
     ASSERT(align, "alignment must be non-zero");
     ASSERT(!(align & (align - 1)), "must align to a power of two");
-    return (size_t) (-(uintptr_t) p) & (align - 1);
+    return (size_t) (align - (uintptr_t) p) & (align - 1);
 }
 
 /* Align pointer while preserving pointer provenance.
@@ -766,16 +770,11 @@ INLINE void mapping(size_t size, uint32_t *fl, uint32_t *sl)
     uint32_t t = log2floor(size);
 
     /* All-ones mask when size is in the linear range (< BLOCK_SIZE_SMALL),
-     * all-zeros when in the logarithmic range.
+     * all-zeros when in the logarithmic range. Subtracting from zero rather
+     * than negating keeps unary minus off an unsigned operand, which MSVC
+     * reports as C4146.
      */
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4146)
-#endif
-    uint32_t small = -(uint32_t) (t < (uint32_t) FL_SHIFT);
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
+    uint32_t small = 0u - (uint32_t) (t < (uint32_t) FL_SHIFT);
 
     /* FL: 0 for small sizes, (t - FL_SHIFT + 1) for large sizes. The wrapping
      * subtraction when t < FL_SHIFT is harmless because ~small masks it to

--- a/src/tlsf.c
+++ b/src/tlsf.c
@@ -1364,7 +1364,10 @@ static void arena_shrink(tlsf_t *t, tlsf_block_t *block)
 {
     check_sentinel(block_next(block));
     size_t size = block_size(block);
-    ASSERT(t->size + BLOCK_OVERHEAD >= size, "invalid heap size before shrink");
+
+    /* Both this block's header and the trailing sentinel are inside t->size. */
+    ASSERT(t->size >= size + 2 * BLOCK_OVERHEAD,
+           "invalid heap size before shrink");
     t->size = t->size - size - BLOCK_OVERHEAD;
     if (t->size == BLOCK_OVERHEAD)
         t->size = 0;

--- a/tests/bench.c
+++ b/tests/bench.c
@@ -12,7 +12,6 @@
  *   Linux)
  */
 
-#include <assert.h>
 #include <errno.h>
 #include <inttypes.h>
 #include <math.h>

--- a/tests/test.c
+++ b/tests/test.c
@@ -205,7 +205,7 @@ static void random_test(tlsf_t *t, size_t spacelen, const size_t cap)
         if (TEST_RAND() % 2 == 0) {
             p[i] = tlsf_malloc(t, len);
         } else {
-            size_t align = 1U << (TEST_RAND() % 20);
+            size_t align = (size_t) 1 << (TEST_RAND() % 20);
             if (cap < align)
                 align = 0;
             p[i] = !align ? tlsf_malloc(t, len) : tlsf_aalloc(t, align, len);

--- a/tests/test.c
+++ b/tests/test.c
@@ -169,6 +169,20 @@ void *tlsf_resize(tlsf_t *t, size_t req_size)
     return start_addr;
 }
 
+/* MSVC's RAND_MAX is 32767, so a bare rand() cannot name every element of an
+ * array longer than 32768. random_test() below builds up to 2 * spacelen live
+ * blocks and frees them by drawing indices, so on MSVC its free loop could
+ * never reach the tail and would spin forever. Draw 30 bits instead. One
+ * spelling for every draw in this file is easier to keep right than two.
+ */
+#if defined(_MSC_VER)
+#define TEST_RAND() ((rand() << 15) | rand())
+#define TEST_RAND_MAX 0x3fffffff
+#else
+#define TEST_RAND() rand()
+#define TEST_RAND_MAX RAND_MAX
+#endif
+
 static void random_test(tlsf_t *t, size_t spacelen, const size_t cap)
 {
     const size_t maxitems = 2 * spacelen;
@@ -184,14 +198,14 @@ static void random_test(tlsf_t *t, size_t spacelen, const size_t cap)
     size_t check_stride = maxitems > 256 ? (maxitems + 255) / 256 : 1;
 
     /* Allocate random sizes up to the cap threshold. Track them in an array. */
-    int64_t rest = (int64_t) spacelen * (rand() % 6 + 1);
+    int64_t rest = (int64_t) spacelen * (TEST_RAND() % 6 + 1);
     unsigned i = 0;
     while (rest > 0 && i < maxitems) {
-        size_t len = ((size_t) rand() % cap) + 1;
-        if (rand() % 2 == 0) {
+        size_t len = ((size_t) TEST_RAND() % cap) + 1;
+        if (TEST_RAND() % 2 == 0) {
             p[i] = tlsf_malloc(t, len);
         } else {
-            size_t align = 1U << (rand() % 20);
+            size_t align = 1U << (TEST_RAND() % 20);
             if (cap < align)
                 align = 0;
             p[i] = !align ? tlsf_malloc(t, len) : tlsf_aalloc(t, align, len);
@@ -201,8 +215,8 @@ static void random_test(tlsf_t *t, size_t spacelen, const size_t cap)
         assert(p[i]);
         rest -= (int64_t) len;
 
-        if (rand() % 10 == 0) {
-            len = ((size_t) rand() % cap) + 1;
+        if (TEST_RAND() % 10 == 0) {
+            len = ((size_t) TEST_RAND() % cap) + 1;
             p[i] = tlsf_realloc(t, p[i], len);
             assert(p[i]);
         }
@@ -231,9 +245,14 @@ static void random_test(tlsf_t *t, size_t spacelen, const size_t cap)
     /* Randomly deallocate the memory blocks until all of them are freed. The
      * free space should match the free space after initialisation.
      */
+    /* Every live index must be drawable or the loop below cannot terminate.
+     * This is what trips if TEST_RAND() is ever narrowed back to rand().
+     */
+    assert(i <= (unsigned) TEST_RAND_MAX + 1u);
+
     size_t freed = 0;
     for (unsigned n = i; n;) {
-        size_t target = (size_t) rand() % i;
+        size_t target = (size_t) TEST_RAND() % i;
         if (p[target] == NULL)
             continue;
 
@@ -254,14 +273,6 @@ static void random_test(tlsf_t *t, size_t spacelen, const size_t cap)
 }
 
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof(x[0]))
-
-#if defined(_MSC_VER)
-static int msvc_large_rand(void)
-{
-    /* 1 billion random number for MSVC */
-    return (rand() << 15) | rand();
-}
-#endif
 
 static void random_sizes_test(tlsf_t *t)
 {
@@ -286,11 +297,7 @@ static void random_sizes_test(tlsf_t *t)
         }
 
         while (n--)
-#if defined(_MSC_VER)
-            random_test(t, sizes[i], (size_t) msvc_large_rand() % sizes[i] + 1);
-#else
-            random_test(t, sizes[i], (size_t) rand() % sizes[i] + 1);
-#endif
+            random_test(t, sizes[i], (size_t) TEST_RAND() % sizes[i] + 1);
         printf(".");
         fflush(stdout);
     }

--- a/tests/test.c
+++ b/tests/test.c
@@ -4,6 +4,13 @@
  * "LICENSE" for information on usage and redistribution of this file.
  */
 
+/* Assertions are the only pass/fail signal these test binaries have, and
+ * several checks below call into the allocator from inside the assertion
+ * itself. A build that defines NDEBUG would compile those calls out, so the
+ * test would exercise nothing and then run on state it never set up. Keep the
+ * checks armed regardless of how the build is configured.
+ */
+#undef NDEBUG
 #include <assert.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/tests/test.c
+++ b/tests/test.c
@@ -454,7 +454,7 @@ static void fragmentation_test(tlsf_t *t)
     double small_avg = small_total / (double) small_count;
     double large_avg = large_total / (double) large_count;
 
-    printf("  SL subdivisions: %u\n", _TLSF_SL_COUNT);
+    printf("  SL subdivisions: %d\n", _TLSF_SL_COUNT);
     printf("  Small sizes (<256B) avg overhead: %.2f%%\n", small_avg);
     printf("  Large sizes (>=256B) avg overhead: %.2f%%\n", large_avg);
     printf("  Large sizes max overhead: %.2f%% (size=%zu)\n", large_max,
@@ -1167,6 +1167,67 @@ static void small_bin_trim_test(void)
            seeded, got);
 }
 
+/* Null arguments and requests past TLSF_MAX_SIZE.
+ *
+ * The null rejects and the TLSF_MAX_SIZE bound are reached by nothing else in
+ * this file. The oversize guard matters most: adjust_size() returns the request
+ * unchanged above TLSF_MAX_SIZE precisely because align_up() would wrap it to
+ * zero and slip past the bounds test at every call site.
+ */
+static void argument_contract_test(void)
+{
+    printf("Argument contract test: ");
+    fflush(stdout);
+
+    static char pool[TLSF_TEST_POOL_CLAMP(64 * 1024)];
+    tlsf_t t;
+    assert(tlsf_pool_init(&t, pool, sizeof(pool)) > 0);
+
+    /* Null arguments are rejected, each with the failure value its return type
+     * calls for. A rejected re-init must leave 't' live.
+     */
+    assert(tlsf_pool_init(NULL, pool, sizeof(pool)) == 0);
+    assert(tlsf_pool_init(&t, NULL, sizeof(pool)) == 0);
+    assert(tlsf_append_pool(NULL, pool, sizeof(pool)) == 0);
+    assert(tlsf_append_pool(&t, NULL, sizeof(pool)) == 0);
+    assert(tlsf_append_pool(&t, pool, 0) == 0);
+    assert(tlsf_usable_size(NULL) == 0);
+
+    tlsf_stats_t stats;
+    assert(tlsf_get_stats(NULL, &stats) == -1);
+    assert(tlsf_get_stats(&t, NULL) == -1);
+
+    /* Freeing null is a no-op the pool survives. */
+    tlsf_free(&t, NULL);
+    tlsf_check(&t);
+
+    /* Requests above TLSF_MAX_SIZE fail instead of wrapping through align_up().
+     * SIZE_MAX is the value that wraps to zero. Both values matter.
+     * TLSF_MAX_SIZE + 1 is the boundary, but only SIZE_MAX makes align_up()
+     * wrap to zero, so only it catches a lost early return in adjust_size().
+     */
+    assert(tlsf_malloc(&t, SIZE_MAX) == NULL);
+    assert(tlsf_malloc(&t, (size_t) TLSF_MAX_SIZE + 1) == NULL);
+    assert(tlsf_aalloc(&t, 64, SIZE_MAX) == NULL);
+
+    /* An aligned request the pool cannot serve fails without disturbing it. */
+    assert(tlsf_aalloc(&t, 4096, sizeof(pool)) == NULL);
+    tlsf_check(&t);
+
+    /* An oversize realloc leaves the original allocation intact. */
+    void *p = tlsf_malloc(&t, 128);
+    assert(p);
+    memset(p, 0x5A, 128);
+    assert(tlsf_realloc(&t, p, SIZE_MAX) == NULL);
+    const unsigned char *data = (const unsigned char *) p;
+    for (int i = 0; i < 128; i++)
+        assert(data[i] == 0x5A);
+    tlsf_free(&t, p);
+
+    tlsf_check(&t);
+    printf("done\n");
+}
+
 static void pool_ceiling_test(void)
 {
     printf("Pool ceiling test: ");
@@ -1510,6 +1571,9 @@ int main(void)
     pool_ceiling_test();
     oversized_free_block_test();
     coalesced_free_block_test(&t);
+
+    /* Run argument contract test */
+    argument_contract_test();
 
     puts("OK!");
     return 0;

--- a/tests/test_thread.c
+++ b/tests/test_thread.c
@@ -8,6 +8,11 @@
  *   - No double-free or use-after-free (ASan / TLSF_ENABLE_CHECK)
  *   - Arena distribution (multiple arenas actually used)
  *   - Aggregate statistics consistency after all threads join
+ *
+ * It also carries weak_resize_test(), which belongs to the core allocator
+ * rather than the wrapper. build/wcet links the weak tlsf_resize() too, but
+ * drives static pools only, so arena_grow() returns before ever calling it.
+ * This is the one binary that both links the weak default and reaches it.
  */
 
 /* Assertions are this program's pass/fail signal; see tests/test.c. */
@@ -384,6 +389,213 @@ static void basic_test(void)
     printf("done\n");
 }
 
+/* Did any of 'ptrs' come out of this arena? Mirrors the range test in
+ * arena_find(), which is file-static in src/tlsf_thread.c and so unreachable
+ * from here.
+ */
+static bool arena_holds_any(const tlsf_arena_t *a, void **ptrs, size_t count)
+{
+    uintptr_t base = (uintptr_t) a->base;
+    for (size_t i = 0; i < count; i++) {
+        uintptr_t addr = (uintptr_t) ptrs[i];
+        if (addr >= base && addr - base < a->capacity)
+            return true;
+    }
+    return false;
+}
+
+/* Test: cross-arena fallback when the preferred arena runs dry.
+ *
+ * arena_select() hashes the thread id, so one thread keeps landing on the same
+ * preferred arena. Draining it pushes every later request through
+ * arena_fallback_alloc(), and running all the way to exhaustion drives that
+ * function's second, blocking pass too, since a request that no arena can serve
+ * visits every lock twice before giving up. Nothing else in this file reaches
+ * either pass: the stress test sizes its arenas so the preferred one never
+ * empties.
+ */
+static void fallback_test(void)
+{
+    printf("Thread cross-arena fallback test: ");
+    fflush(stdout);
+
+    size_t usable = tlsf_thread_init(&ts, pool, sizeof(pool));
+    assert(usable > 0);
+
+    if (ts.count < 2) {
+        tlsf_thread_destroy(&ts);
+        printf("skipped (single arena)\n");
+        return;
+    }
+
+    /* About four blocks per arena, which bounds the pointer table below. */
+    size_t chunk = usable / (4 * (size_t) ts.count);
+    assert(chunk > TLSF_TEST_BLOCK_COST);
+
+    void *ptrs[4 * TLSF_ARENA_COUNT + 8];
+    size_t count = 0;
+    void *p;
+    while ((p = tlsf_thread_malloc(&ts, chunk)) != NULL) {
+        assert(count < sizeof(ptrs) / sizeof(ptrs[0]));
+        ptrs[count++] = p;
+    }
+    assert(count > 0); /* the loop ended when no arena could serve chunk */
+
+    /* Every arena contributed, which only the fallback path can arrange: a
+     * single thread asks the same preferred arena every time.
+     */
+    int served = 0;
+    for (int i = 0; i < ts.count; i++)
+        served += arena_holds_any(&ts.arenas[i], ptrs, count);
+    assert(served == ts.count);
+
+    /* With nothing left anywhere, a growing realloc cannot expand in place and
+     * cannot relocate either. It must fail without touching the original.
+     */
+    memset(ptrs[0], 0x3C, chunk);
+    assert(tlsf_thread_realloc(&ts, ptrs[0], chunk * 2) == NULL);
+    const unsigned char *kept = (const unsigned char *) ptrs[0];
+    for (size_t i = 0; i < chunk; i++)
+        assert(kept[i] == 0x3C);
+
+    for (size_t i = 0; i < count; i++)
+        tlsf_thread_free(&ts, ptrs[i]);
+    tlsf_thread_check(&ts);
+
+    tlsf_stats_t stats;
+    tlsf_thread_stats(&ts, &stats);
+    assert(stats.total_used == 0);
+
+    printf("%zu blocks across %d arenas, done\n", count, ts.count);
+    tlsf_thread_destroy(&ts);
+}
+
+/* Test: init paths the fixed 4 MB pool never reaches.
+ *
+ * A region too small to split TLSF_ARENA_COUNT ways drives the halving loop; a
+ * region too small for even one arena drives the rollback that destroys the
+ * locks created so far and leaves the instance zeroed. The remaining rollback,
+ * the one for a failed lock init, needs TLSF_LOCK_INIT() to fail and has no
+ * portable trigger.
+ */
+static void init_limits_test(void)
+{
+    printf("Thread init limits test: ");
+    fflush(stdout);
+
+    static tlsf_thread_t small;
+
+    /* One word short of what tlsf_pool_init() accepts, so the first arena fails
+     * and init unwinds.
+     */
+    TLSF_MSVC_ALIGN(16)
+    static char cramped[TLSF_TEST_BLOCK_COST] TLSF_GCC_ALIGN(16);
+    assert(tlsf_thread_init(&small, cramped, sizeof(cramped)) == 0);
+    assert(small.count == 0);
+
+    /* A failed instance is inert rather than dangerous. */
+    assert(tlsf_thread_malloc(&small, 16) == NULL);
+    tlsf_thread_free(&small, NULL);
+    tlsf_thread_check(&small);
+    tlsf_thread_destroy(&small);
+
+    /* Too small to divide TLSF_ARENA_COUNT ways: the count halves until each
+     * share clears the per-arena minimum. Two arenas' worth of the 256-byte
+     * per-arena minimum that tlsf_thread_init() enforces, so the count has to
+     * halve at least once.
+     */
+    TLSF_MSVC_ALIGN(16) static char narrow[2 * 256] TLSF_GCC_ALIGN(16);
+    size_t usable = tlsf_thread_init(&small, narrow, sizeof(narrow));
+    assert(usable > 0);
+    assert(small.count >= 1);
+#if TLSF_ARENA_COUNT > 2
+    assert(small.count < TLSF_ARENA_COUNT);
+#endif
+
+    void *p = tlsf_thread_malloc(&small, 32);
+    assert(p);
+    tlsf_thread_free(&small, p);
+    tlsf_thread_check(&small);
+
+    printf("%zu bytes seated %d of %d arenas, done\n", sizeof(narrow),
+           small.count, TLSF_ARENA_COUNT);
+    tlsf_thread_destroy(&small);
+}
+
+/* Test: the weak tlsf_resize() default.
+ *
+ * This binary supplies no strong definition, so a dynamic arena has no backend
+ * to grow from and every allocation must fail rather than hand out memory that
+ * was never mapped. tests/test.c and tests/bench.c cannot check this; both
+ * define their own tlsf_resize(). tests/wcet.c links the weak one but never
+ * reaches it, since it allocates only from static pools.
+ */
+static void weak_resize_test(void)
+{
+    printf("Weak tlsf_resize default test: ");
+    fflush(stdout);
+
+    /* Zeroed, so not a fixed pool: growth goes through tlsf_resize(). */
+    static tlsf_t dynamic;
+
+    assert(tlsf_malloc(&dynamic, 64) == NULL);
+    assert(tlsf_aalloc(&dynamic, 256, 64) == NULL);
+
+    tlsf_stats_t stats;
+    assert(tlsf_get_stats(&dynamic, &stats) == 0);
+    assert(stats.total_used == 0);
+    assert(stats.block_count == 0);
+
+    printf("done\n");
+}
+
+/* Test: null and foreign arguments across the wrapper API.
+ *
+ * Same gap as argument_contract_test() in tests/test.c, one layer up: every one
+ * of these is a pure rejection path that the functional tests never enter. The
+ * foreign-pointer cases matter most, since arena_find() failing to place a
+ * pointer is the wrapper's only defense against operating on memory it does not
+ * own.
+ */
+static void null_argument_test(void)
+{
+    printf("Thread null argument test: ");
+    fflush(stdout);
+
+    assert(tlsf_thread_init(&ts, pool, sizeof(pool)) > 0);
+
+    assert(tlsf_thread_init(NULL, pool, sizeof(pool)) == 0);
+    assert(tlsf_thread_init(&ts, NULL, sizeof(pool)) == 0);
+    assert(tlsf_thread_init(&ts, pool, 0) == 0);
+
+    assert(tlsf_thread_malloc(NULL, 16) == NULL);
+    assert(tlsf_thread_aalloc(&ts, 0, 16) == NULL);
+    assert(tlsf_thread_realloc(NULL, NULL, 16) == NULL);
+
+    tlsf_thread_free(NULL, NULL);
+    tlsf_thread_check(NULL);
+    tlsf_thread_reset(NULL);
+    tlsf_thread_destroy(NULL);
+
+    tlsf_stats_t stats;
+    assert(tlsf_thread_stats(NULL, &stats) == -1);
+    assert(tlsf_thread_stats(&ts, NULL) == -1);
+
+    /* A pointer no arena owns is refused rather than acted on. */
+    char foreign[64];
+    tlsf_thread_free(&ts, foreign);
+    assert(tlsf_thread_realloc(&ts, foreign, 32) == NULL);
+
+    /* The instance is unharmed by all of it. */
+    tlsf_thread_check(&ts);
+    void *p = tlsf_thread_malloc(&ts, 64);
+    assert(p);
+    tlsf_thread_free(&ts, p);
+
+    tlsf_thread_destroy(&ts);
+    printf("done\n");
+}
+
 /* Main */
 
 int main(void)
@@ -395,6 +607,10 @@ int main(void)
     stress_test();
     aligned_test();
     reset_test();
+    fallback_test();
+    init_limits_test();
+    weak_resize_test();
+    null_argument_test();
 
     puts("OK!");
     return 0;

--- a/tests/test_thread.c
+++ b/tests/test_thread.c
@@ -10,8 +10,9 @@
  *   - Aggregate statistics consistency after all threads join
  */
 
+/* Assertions are this program's pass/fail signal; see tests/test.c. */
+#undef NDEBUG
 #include <assert.h>
-// #include <pthread.h>
 #include <stdint.h>
 #include <stdio.h>
 #if defined(_MSC_VER)

--- a/tests/wcet.c
+++ b/tests/wcet.c
@@ -28,6 +28,14 @@
 #define _CRT_SECURE_NO_WARNINGS 1
 #endif
 
+/* See tests/test.c. Here the assertions also gate the measurement: with them
+ * compiled out, a failed setup allocation leaves NULL and the loop times
+ * tlsf_free() on it, then reports that as a latency bound. Every assertion sits
+ * outside the read_tick() pair, and every one inside an iteration loop is
+ * followed by cache_thrash(), so no assertion residue reaches a measured region
+ * either.
+ */
+#undef NDEBUG
 #include <assert.h>
 #include <inttypes.h>
 #include <math.h>
@@ -294,7 +302,6 @@ static void measure_malloc_worst(char *pool,
         tick_t end = read_tick();
 
         assert(p);
-        (void) p;
         samples[i] = end - start;
     }
 }
@@ -328,7 +335,6 @@ static void measure_malloc_best(char *pool,
         tlsf_free(&t, a);
         void *b = tlsf_malloc(&t, alloc_size);
         assert(b);
-        (void) b;
     }
 
     for (size_t i = 0; i < iterations; i++) {
@@ -336,7 +342,6 @@ static void measure_malloc_best(char *pool,
         void *a = tlsf_malloc(&t, alloc_size);
         void *sep = tlsf_malloc(&t, 1);
         assert(a && sep);
-        (void) sep;
         tlsf_free(&t, a);
         cache_thrash();
 
@@ -345,7 +350,6 @@ static void measure_malloc_best(char *pool,
         tick_t end = read_tick();
 
         assert(b);
-        (void) b;
         samples[i] = end - start;
     }
 }

--- a/tests/wcet.c
+++ b/tests/wcet.c
@@ -238,7 +238,8 @@ static void compute_latency_stats(tick_t *samples, size_t n, latency_stats_t *s)
  * including memory latency.
  */
 
-#define THRASH_SIZE (64U << 20) /* 64 MB -- exceeds typical L2 and most L3 */
+/* 64 MB: exceeds typical L2 and most L3 */
+#define THRASH_SIZE ((size_t) 64 << 20)
 
 static char *thrash_buf;
 


### PR DESCRIPTION
The C4146 error is real. The release-mode crash was not in the allocator:
`tests/test.c` called `tlsf_pool_init()` from inside `assert()`, so NDEBUG
deleted the call and the static pool test ran on an uninitialized `tlsf_t`.
Reproduced here with `-DNDEBUG`: signal 10, same stack as reported.

- Neither site needs a negation. `align_offset()` wants the distance to the
  next boundary, which is `align - p` masked; `mapping()` wants a 0/1 widened
  to a mask, which is `0u - x`. Both are binary subtraction, which C4146 does
  not cover, so the `#pragma warning` island goes with nothing replacing it.
  The MSVC jobs now pass `/we4146`, since nothing enforced this before.
- `#undef NDEBUG` in the three test binaries, plus a `-DNDEBUG` CI row.
  Removing the undef again faults that row, so it is a real check.

The rest closes what let that ship unnoticed.

- `arena_fallback_alloc()` had zero coverage, and every oversize and
  null-argument reject was untested. `tlsf.c` 96.99% to 98.22%,
  `tlsf_thread.c` 76.97% to 96.07%.
- The assertions-off build, the one users ship, was compiled by no CI job.
  `TLSF_DEBUG_FLAGS` makes it reachable and CI runs it. The build now also
  rebuilds when flags change, which additionally repairs incremental builds:
  before this, `touch include/tlsf.h && make all` failed outright.
- `make verify` ran with `ASSERT()` compiled out, hiding 160 goals. Three now
  prove; six are filed rather than papered over.
- `tlsf_realloc()` 95 lines at depth 5 to 43 at depth 3, `tlsf_check()` 181/5
  to 16/1. Behavior-preserving: a differential trace against master is
  byte-identical over 200k operations across 10 seeds.

Close #34