### PR TITLE
Fix C++ builds

### DIFF
--- a/.ci/check-format.sh
+++ b/.ci/check-format.sh
@@ -16,15 +16,15 @@ PY_FORMAT_EXIT=0
 C_SOURCES=()
 while IFS= read -r file; do
 	[ -n "$file" ] && C_SOURCES+=("$file")
-done < <(git ls-files -- 'include/*.h' 'src/*.c' 'src/*.h' 'ports/*.c' 'ports/*.h' 'tests/*.c' 'tests/*.h')
+done < <(git ls-files -- 'include/*.h' 'src/*.c' 'src/*.h' 'ports/*.c' 'ports/*.h' 'tests/*.c' 'tests/*.h' 'tests/*.cpp')
 
 if [ ${#C_SOURCES[@]} -gt 0 ]; then
 	if command -v clang-format-20 >/dev/null 2>&1; then
-		echo "Checking C files with clang-format-20..."
+		echo "Checking C and C++ files with clang-format-20..."
 		clang-format-20 -n --Werror "${C_SOURCES[@]}"
 		C_FORMAT_EXIT=$?
 	elif command -v clang-format >/dev/null 2>&1; then
-		echo "Checking C files with clang-format..."
+		echo "Checking C and C++ files with clang-format..."
 		clang-format -n --Werror "${C_SOURCES[@]}"
 		C_FORMAT_EXIT=$?
 	else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,12 +102,14 @@ jobs:
         run: make all
         env:
           CC: ${{ matrix.cc }}
-          CFLAGS: ${{ matrix.cflags }}
+          CXX: ${{ matrix.cc == 'clang' && 'clang++' || 'g++' }}
+          CPPFLAGS: ${{ matrix.cflags }}
       - name: Test
         run: make check
         env:
           CC: ${{ matrix.cc }}
-          CFLAGS: ${{ matrix.cflags }}
+          CXX: ${{ matrix.cc == 'clang' && 'clang++' || 'g++' }}
+          CPPFLAGS: ${{ matrix.cflags }}
   
   # 32-bit build: exercises the _TLSF_SIZE_WIDTH == 32 paths (ALIGN_SHIFT 2,
   # _TLSF_FL_MAX 31, __builtin_clzl) that the 64-bit matrix never compiles.
@@ -117,17 +119,17 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Install multilib toolchain
-        run: sudo apt-get update && sudo apt-get install -y gcc-multilib
+        run: sudo apt-get update && sudo apt-get install -y gcc-multilib g++-multilib
         env:
           DEBIAN_FRONTEND: noninteractive
       - name: Build
         run: make all
         env:
-          CFLAGS: "-m32"
+          CPPFLAGS: "-m32"
       - name: Test
         run: make check
         env:
-          CFLAGS: "-m32"
+          CPPFLAGS: "-m32"
 
   # Deductive verification of the annotated leaf helpers. Runs in the official
   # Frama-C image so the job does not pay for an opam build on every push.
@@ -194,7 +196,7 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
       - name: Build (release, no assert/check overhead)
-        run: make all CFLAGS="-Iinclude -std=gnu11 -O2 -Wall -Wextra -Wconversion"
+        run: make all TLSF_DEBUG_FLAGS= CFLAGS="-Iinclude -std=gnu11 -O2 -Wall -Wextra -Wconversion"
       - name: WCET measurement
         run: ./build/wcet -i 5000 -w 500 -r build/wcet_raw.csv | tee build/wcet_output.txt
       - name: Generate plots

--- a/Makefile
+++ b/Makefile
@@ -59,10 +59,12 @@ $(OUT)/test: $(OBJS) tests/test.c
 	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
 
 $(OUT)/bench: $(OBJS) tests/bench.c
-	$(CC) $(CFLAGS) -o $@ -MMD -MF $@.d $^ $(LDFLAGS) -lm
+	$(CC) $(CFLAGS) -o $@ -MMD -MF $@.d $(OBJS) tests/bench.c \
+		$(LDFLAGS) -lm
 
 $(OUT)/wcet: $(OBJS) tests/wcet.c
-	$(CC) $(CFLAGS) -o $@ -MMD -MF $@.d $^ $(LDFLAGS) -lm
+	$(CC) $(CFLAGS) -o $@ -MMD -MF $@.d $(OBJS) tests/wcet.c \
+		$(LDFLAGS) -lm
 
 # Thread-safe module (requires pthreads)
 $(OUT)/tlsf_thread.o: src/tlsf_thread.c include/tlsf_thread.h
@@ -70,7 +72,8 @@ $(OUT)/tlsf_thread.o: src/tlsf_thread.c include/tlsf_thread.h
 	$(CC) $(CFLAGS) -pthread -c -o $@ -MMD -MF $@.d $<
 
 $(OUT)/test_thread: $(OBJS) $(THREAD_OBJS) tests/test_thread.c
-	$(CC) $(CFLAGS) -pthread -o $@ -MMD -MF $@.d $^ $(LDFLAGS)
+	$(CC) $(CFLAGS) -pthread -o $@ -MMD -MF $@.d $(OBJS) \
+		$(THREAD_OBJS) tests/test_thread.c $(LDFLAGS)
 
 $(OUT)/%.o: src/%.c
 	@mkdir -p $(OUT)

--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,9 @@ TARGETS = \
 TARGETS := $(addprefix $(OUT)/,$(TARGETS))
 
 THREAD_TARGETS = $(OUT)/test_thread
+CPP_TARGETS = $(OUT)/test_cpp
 
-all: $(TARGETS) $(THREAD_TARGETS)
+all: $(TARGETS) $(THREAD_TARGETS) $(CPP_TARGETS)
 
 # Full benchmark with statistical rigor (50 iterations, 5 warmup)
 bench: all
@@ -39,11 +40,34 @@ bench: all
 bench-quick: all
 	build/bench -s 64:4096 -l 100000 -i 10 -w 3
 
+# Clear this to build and test the library the way it ships. It is the only
+# way the off-branches of TLSF_ENABLE_ASSERT and TLSF_ENABLE_CHECK ever get
+# compiled: 'make check TLSF_DEBUG_FLAGS='.
+TLSF_DEBUG_FLAGS ?= -DTLSF_ENABLE_ASSERT -DTLSF_ENABLE_CHECK
+
+# Preprocessor state shared by every translation unit, C and C++ alike.
+# Configuration macros change the layout of tlsf_t, and a mismatch between two
+# objects in the same binary is not diagnosed, so they must not live in a
+# language-specific variable. Anything a caller injects through CPPFLAGS
+# reaches both compilers for the same reason.
+override CPPFLAGS += -Iinclude $(TLSF_DEBUG_FLAGS)
+
+TLSF_WARNINGS = \
+  -Wall -Wextra -Wshadow -Wpointer-arith -Wcast-qual -Wconversion
+
 CFLAGS += \
-  -Iinclude \
   -std=gnu11 -g -O2 \
-  -Wall -Wextra -Wshadow -Wpointer-arith -Wcast-qual -Wconversion -Wc++-compat \
-  -DTLSF_ENABLE_ASSERT -DTLSF_ENABLE_CHECK
+  $(TLSF_WARNINGS) -Wc++-compat
+
+CXXFLAGS += \
+  -std=c++11 -g -O2 \
+  $(TLSF_WARNINGS) -pedantic-errors
+
+# The header's own knobs are spelled '_TLSF_' as well as 'TLSF_', and either
+# prefix can arrive as -U rather than -D, so all four forms have to be caught.
+ifneq ($(filter -DTLSF_% -D_TLSF_% -UTLSF_% -U_TLSF_%,$(CFLAGS) $(CXXFLAGS)),)
+$(error Pass TLSF configuration macros through CPPFLAGS, not CFLAGS or CXXFLAGS)
+endif
 
 OBJS = tlsf.o
 OBJS := $(addprefix $(OUT)/,$(OBJS))
@@ -53,39 +77,44 @@ THREAD_OBJS = $(OUT)/tlsf_thread.o
 # Every rule that passes -MMD -MF must be listed, or 'clean' leaves its dep
 # file behind. $(OUT)/test is deliberately absent: its rule emits no dep file.
 deps := $(OBJS:%.o=%.o.d) $(THREAD_OBJS:%.o=%.o.d) \
-	$(OUT)/bench.d $(OUT)/wcet.d $(THREAD_TARGETS:%=%.d)
+	$(OUT)/bench.d $(OUT)/wcet.d $(THREAD_TARGETS:%=%.d) $(CPP_TARGETS:%=%.d)
 
 $(OUT)/test: $(OBJS) tests/test.c
-	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
+	$(CC) $(CPPFLAGS) $(CFLAGS) -o $@ $^ $(LDFLAGS)
 
 $(OUT)/bench: $(OBJS) tests/bench.c
-	$(CC) $(CFLAGS) -o $@ -MMD -MF $@.d $(OBJS) tests/bench.c \
+	$(CC) $(CPPFLAGS) $(CFLAGS) -o $@ -MMD -MF $@.d $(OBJS) tests/bench.c \
 		$(LDFLAGS) -lm
 
 $(OUT)/wcet: $(OBJS) tests/wcet.c
-	$(CC) $(CFLAGS) -o $@ -MMD -MF $@.d $(OBJS) tests/wcet.c \
+	$(CC) $(CPPFLAGS) $(CFLAGS) -o $@ -MMD -MF $@.d $(OBJS) tests/wcet.c \
 		$(LDFLAGS) -lm
 
 # Thread-safe module (requires pthreads)
 $(OUT)/tlsf_thread.o: src/tlsf_thread.c include/tlsf_thread.h
 	@mkdir -p $(OUT)
-	$(CC) $(CFLAGS) -pthread -c -o $@ -MMD -MF $@.d $<
+	$(CC) $(CPPFLAGS) $(CFLAGS) -pthread -c -o $@ -MMD -MF $@.d $<
 
 $(OUT)/test_thread: $(OBJS) $(THREAD_OBJS) tests/test_thread.c
-	$(CC) $(CFLAGS) -pthread -o $@ -MMD -MF $@.d $(OBJS) \
+	$(CC) $(CPPFLAGS) $(CFLAGS) -pthread -o $@ -MMD -MF $@.d $(OBJS) \
 		$(THREAD_OBJS) tests/test_thread.c $(LDFLAGS)
+
+$(OUT)/test_cpp: $(OBJS) $(THREAD_OBJS) tests/test_cpp.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -pthread -o $@ -MMD -MF $@.d $(OBJS) \
+		$(THREAD_OBJS) tests/test_cpp.cpp $(LDFLAGS)
 
 $(OUT)/%.o: src/%.c
 	@mkdir -p $(OUT)
-	$(CC) $(CFLAGS) -c -o $@ -MMD -MF $@.d $<
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c -o $@ -MMD -MF $@.d $<
 
-check: $(TARGETS) $(THREAD_TARGETS)
+check: $(TARGETS) $(THREAD_TARGETS) $(CPP_TARGETS)
 	MALLOC_CHECK_=3 ./build/test
 	MALLOC_CHECK_=3 ./build/bench -l 10000 -i 3 -w 1
 	MALLOC_CHECK_=3 ./build/bench -s 32 -l 10000 -i 3 -w 1
 	MALLOC_CHECK_=3 ./build/bench -s 10:12345 -l 10000 -i 3 -w 1
 	./build/wcet -i 100 -w 10
 	./build/test_thread
+	./build/test_cpp
 
 # RTE guards are emitted as ACSL asserts, so filtering out @assert would discard
 # every runtime-error obligation that -wp-rte just generated. Keep them counted.
@@ -127,7 +156,8 @@ wcet-plot: all
 	python3 scripts/wcet_plot.py $(OUT)/wcet_raw.csv -o $(OUT)/wcet
 
 clean:
-	$(RM) $(TARGETS) $(THREAD_TARGETS) $(OBJS) $(THREAD_OBJS) $(deps)
+	$(RM) $(TARGETS) $(THREAD_TARGETS) $(CPP_TARGETS)
+	$(RM) $(OBJS) $(THREAD_OBJS) $(deps)
 	$(RM) $(OUT)/wcet_raw.csv $(OUT)/wcet_summary.csv
 	$(RM) $(OUT)/wcet_boxplot.png $(OUT)/wcet_histogram.png
 	$(RM) -r $(OUT)/*.dSYM

--- a/include/tlsf.h
+++ b/include/tlsf.h
@@ -111,35 +111,55 @@ extern "C" {
 /* An allocator with no arena yet. The first tlsf_malloc() grows one through
  * tlsf_resize(), so an instance initialized this way needs that callback.
  */
-#define TLSF_INIT ((tlsf_t) {.size = 0})
-
-/* The same value for objects with static storage duration. MSVC rejects a
- * compound literal as a static initializer, so it gets the bare brace form.
+#if defined(__cplusplus)
+/* A compound literal is not C++ at all. Value initialization zeroes every
+ * member instead, and because tlsf_t is an aggregate with no user-provided
+ * constructor it is a constant expression, so this also serves objects with
+ * static storage duration.
  */
-#if defined(_MSC_VER)
+#define TLSF_INIT tlsf_t()
+#else
+#define TLSF_INIT ((tlsf_t) {.size = 0})
+#endif
+
+/* The same value for objects with static storage duration. Only MSVC's C mode
+ * needs a different spelling, because it rejects a compound literal as a static
+ * initializer; everywhere else, including C++, the two macros cannot drift.
+ */
+#if defined(_MSC_VER) && !defined(__cplusplus)
 #define TLSF_INIT_STATIC {.size = 0}
 #else
-#define TLSF_INIT_STATIC ((tlsf_t) {.size = 0})
+#define TLSF_INIT_STATIC TLSF_INIT
 #endif
 
 #ifndef TLSF_STATIC_ASSERT
-#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)
+#if defined(__cplusplus) && (__cplusplus >= 201103L)
+#define TLSF_STATIC_ASSERT(cond, msg) static_assert(cond, msg)
+#elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)
 #define TLSF_STATIC_ASSERT(cond, msg) _Static_assert(cond, msg)
-#elif defined(__clang__)
+#elif !defined(__cplusplus) && defined(__clang__)
 #if __has_extension(c_static_assert) || __has_feature(c_static_assert)
 #define TLSF_STATIC_ASSERT(cond, msg) _Static_assert(cond, msg)
 #endif
-#elif defined(__GNUC__) &&                                        \
+#elif !defined(__cplusplus) && defined(__GNUC__) &&               \
     ((__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)) && \
     !defined(__STRICT_ANSI__)
 #define TLSF_STATIC_ASSERT(cond, msg) _Static_assert(cond, msg)
-#else
+#endif
+#endif
+
+/* Everything the ladder above did not claim lands here: pre-C11 compilers,
+ * pre-C++11 compilers, and a clang whose nested __has_extension test came out
+ * false. That last case is why the fallback cannot be an '#else' arm of the
+ * ladder; an '#elif' that a nested '#if' declines to fill would otherwise
+ * leave the macro undefined.
+ */
+#ifndef TLSF_STATIC_ASSERT
 #define TLSF_SASSERT_GLUE(a, b) a##b
 #define TLSF_SASSERT_JOIN(a, b) TLSF_SASSERT_GLUE(a, b)
 #define TLSF_STATIC_ASSERT(cond, msg)                             \
     typedef char TLSF_SASSERT_JOIN(STATIC_ASSERT_FAILED_AT_LINE_, \
                                    __LINE__)[(cond) ? 1 : -1]
-#endif
 #endif
 
 /* Block header structure.

--- a/tests/test_cpp.cpp
+++ b/tests/test_cpp.cpp
@@ -1,0 +1,79 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+/* Compiling this file is most of the test: the public headers have to parse as
+ * C++, and the C objects have to link against a C++ translation unit. What runs
+ * afterwards only confirms the headers agree with the library they were built
+ * against, so it must not lean on assert(), which NDEBUG deletes along with any
+ * side effect inside it.
+ */
+
+#include <stdio.h>
+
+#include "tlsf.h"
+#include "tlsf_thread.h"
+
+#define CHECK(cond)                                                    \
+    do {                                                               \
+        if (!(cond)) {                                                 \
+            fprintf(stderr, "%s:%d: %s\n", __FILE__, __LINE__, #cond); \
+            return 1;                                                  \
+        }                                                              \
+    } while (0)
+
+/* TLSF_INIT_STATIC is a separate macro because MSVC's C mode needs its own
+ * spelling for a static initializer. Everywhere else it aliases TLSF_INIT.
+ *
+ * 'constexpr' is what holds the C++ form to constant initialization. Namespace
+ * scope alone proves nothing: C++ accepts dynamic initialization there without
+ * a diagnostic, so 'static_instance' below would compile either way.
+ */
+constexpr tlsf_t constant_instance = TLSF_INIT_STATIC;
+static tlsf_t static_instance = TLSF_INIT_STATIC;
+
+static int core_test(void)
+{
+    alignas(16) unsigned char memory[16 * 1024];
+    tlsf_t tlsf = TLSF_INIT;
+
+    CHECK(tlsf.size == 0);
+    CHECK(static_instance.size == 0);
+    CHECK(constant_instance.size == 0);
+    CHECK(tlsf_pool_init(&tlsf, memory, sizeof(memory)) > 0);
+
+    void *ptr = tlsf_malloc(&tlsf, 64);
+    CHECK(ptr);
+    CHECK(tlsf_usable_size(ptr) >= 64);
+    tlsf_free(&tlsf, ptr);
+    tlsf_check(&tlsf);
+    return 0;
+}
+
+static int thread_test(void)
+{
+    alignas(TLSF_CACHELINE_SIZE) unsigned char memory[64 * 1024];
+    tlsf_thread_t tlsf;
+
+    /* Nothing to release when this fails: tlsf_thread_init() destroys the locks
+     * it had already created and zeroes the instance.
+     */
+    CHECK(tlsf_thread_init(&tlsf, memory, sizeof(memory)) > 0);
+
+    void *ptr = tlsf_thread_malloc(&tlsf, 64);
+    if (ptr) {
+        tlsf_thread_free(&tlsf, ptr);
+        tlsf_thread_check(&tlsf);
+    }
+    tlsf_thread_destroy(&tlsf);
+    CHECK(ptr);
+    return 0;
+}
+
+int main()
+{
+    /* Not '||': short-circuiting would skip thread_test() whenever
+     * core_test() fails, hiding a second broken area behind the first.
+     */
+    int failed = core_test();
+    failed |= thread_test();
+    return failed;
+}


### PR DESCRIPTION
Close #36


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the public headers so documented C++ usage compiles, and adds a C++ test to `make check`.

- `TLSF_INIT` uses value initialization in C++ and `TLSF_STATIC_ASSERT` gains a C++11 `static_assert` arm; the fallback moves to a trailing `#ifndef` so clang's nested check can't leave it undefined.
- TLSF configuration macros move to `CPPFLAGS` so both compilers agree on the `tlsf_t` layout; the Makefile now rejects them in `CFLAGS` or `CXXFLAGS`.
- Fixes a Makefile bug where headers from `.d` files leaked into link commands and broke rebuilds after header changes.
- CI builds the new test with `CXX` and runs clang-format on it.

<sup>Written for commit d23cb2acad2156c0cfea146d724c173f462811af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/tlsf-bsd/pull/37?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



