### PR TITLE
Fix `tlsf_check()` aborting on healthy heaps

### DIFF
--- a/.ci/check-abi-guard.sh
+++ b/.ci/check-abi-guard.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# The layout of 'tlsf_t' and 'tlsf_thread_t' moves with the configuration
+# macros, and callers allocate both. Mismatched translation units used to link
+# cleanly and then write past the end of the caller's object. The public symbol
+# names now carry the layout knobs, so a mismatch is an undefined reference.
+#
+# Checked both ways. A mismatched pair must fail to link, which is the half that
+# catches a regression reintroducing the corruption. A matched pair must still
+# link and run, which is the half that catches a guard so aggressive it breaks
+# ordinary builds. Only the caller's flags vary, so the library is built once.
+set -e -u -o pipefail
+
+CC="${CC:-cc}"
+CFLAGS_COMMON="-Iinclude -std=gnu11 -O1 -pthread"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+cat >"$tmp/core.c" <<'EOF'
+#include "tlsf.h"
+static char pool[1 << 16];
+int main(void)
+{
+	tlsf_t t;
+	return tlsf_pool_init(&t, pool, sizeof(pool)) && tlsf_malloc(&t, 64) ? 0 : 1;
+}
+EOF
+
+cat >"$tmp/thread.c" <<'EOF'
+#include "tlsf_thread.h"
+static char mem[1 << 20];
+int main(void)
+{
+	tlsf_thread_t ts;
+	return tlsf_thread_init(&ts, mem, sizeof(mem)) ? 0 : 1;
+}
+EOF
+
+# shellcheck disable=SC2086
+$CC $CFLAGS_COMMON -c -o "$tmp/tlsf.o" src/tlsf.c
+# shellcheck disable=SC2086
+$CC $CFLAGS_COMMON -c -o "$tmp/tlsf_thread.o" src/tlsf_thread.c
+
+ret=0
+
+# check <links|fails> <caller flags> <core|thread> <description>
+check() {
+	expect="$1"
+	flags="$2"
+	case "$3" in
+	core) src="$tmp/core.c" objs="$tmp/tlsf.o" ;;
+	thread) src="$tmp/thread.c" objs="$tmp/tlsf.o $tmp/tlsf_thread.o" ;;
+	esac
+	desc="$4"
+
+	# shellcheck disable=SC2086
+	$CC $CFLAGS_COMMON $flags -c -o "$tmp/caller.o" "$src"
+	# shellcheck disable=SC2086
+	if $CC -pthread -o "$tmp/out" "$tmp/caller.o" $objs \
+		>"$tmp/link.log" 2>&1; then
+		got=links
+	else
+		got=fails
+	fi
+
+	if [ "$got" != "$expect" ]; then
+		echo "FAIL: $desc: expected link to $expect, got $got"
+		sed 's/^/    /' <"$tmp/link.log"
+		ret=1
+		return
+	fi
+
+	# A matched build must also work, not merely resolve its symbols.
+	if [ "$expect" = links ] && ! "$tmp/out"; then
+		echo "FAIL: $desc: linked but exited non-zero"
+		ret=1
+		return
+	fi
+
+	echo "ok: $desc ($got)"
+}
+
+check links "" core "core: matched configuration"
+check fails "-DTLSF_MAX_POOL_BITS=20" core "core: TLSF_MAX_POOL_BITS mismatch"
+
+# This keeps '_TLSF_FL_MAX' equal on both sides, so only the size-width suffix
+# can reject the layout mismatch.
+# shellcheck disable=SC2086
+$CC $CFLAGS_COMMON -D_TLSF_SIZE_WIDTH=32 -DTLSF_MAX_POOL_BITS=20 -c \
+	-o "$tmp/tlsf-w32-fl20.o" src/tlsf.c
+# shellcheck disable=SC2086
+$CC $CFLAGS_COMMON -DTLSF_MAX_POOL_BITS=20 -c -o "$tmp/caller.o" "$tmp/core.c"
+if $CC -pthread -o "$tmp/out" "$tmp/caller.o" "$tmp/tlsf-w32-fl20.o" \
+	>"$tmp/link.log" 2>&1; then
+	echo "FAIL: core: _TLSF_SIZE_WIDTH mismatch: expected link to fail, got links"
+	ret=1
+else
+	echo "ok: core: _TLSF_SIZE_WIDTH mismatch (fails)"
+fi
+
+check links "" thread "thread: matched configuration"
+check fails "-DTLSF_ARENA_COUNT=8" thread "thread: TLSF_ARENA_COUNT mismatch"
+check fails "-DTLSF_CACHELINE_SIZE=128" thread "thread: TLSF_CACHELINE_SIZE mismatch"
+
+# TLSF_C11_THREADS does not decide the lock backend on its own. The header
+# selects on USE_C11_THREADS, which needs the compiler to actually have C11
+# threads and is also set on Windows without the flag, so whether the flag
+# changes anything is a property of the host. Ask the header which backend it
+# picked rather than inferring it.
+#
+# Do not infer it from sizeof either. On glibc, mtx_t and pthread_mutex_t are
+# the same size, so the wrapper measures identical while the lock operations
+# compiled into it differ, and mixing those two builds is exactly what this
+# guard must reject.
+cat >"$tmp/backend.c" <<'EOF'
+#include <stdio.h>
+#include "tlsf_thread.h"
+int main(void)
+{
+	printf("%d\n", _TLSF_THREAD_C11_THREADS);
+	return 0;
+}
+EOF
+# shellcheck disable=SC2086
+$CC $CFLAGS_COMMON -o "$tmp/backend_plain" "$tmp/backend.c"
+# shellcheck disable=SC2086
+$CC $CFLAGS_COMMON -DTLSF_C11_THREADS -o "$tmp/backend_c11" "$tmp/backend.c"
+plain="$("$tmp/backend_plain")"
+c11="$("$tmp/backend_c11")"
+
+if [ "$plain" = "$c11" ]; then
+	echo "note: TLSF_C11_THREADS selects the same lock backend here" \
+		"(both $plain), so the two builds must stay compatible"
+	check links "-DTLSF_C11_THREADS" thread \
+		"thread: TLSF_C11_THREADS with the same backend"
+else
+	check fails "-DTLSF_C11_THREADS" thread \
+		"thread: TLSF_C11_THREADS mismatch"
+fi
+
+exit $ret

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
         run: bash .ci/check-format.sh
       - name: Check trailing newlines
         run: bash .ci/check-newline.sh
+      - name: Check configuration ABI guard
+        run: bash .ci/check-abi-guard.sh
 
   build-and-test:
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,32 +150,42 @@ jobs:
 
   build-windows-msvc:
     runs-on: windows-latest
-    timeout-minutes: 10
+    # A healthy run finishes in well under a minute. The old ten minute limit
+    # only ever applied to a hang, where it spent nine of them confirming what
+    # the first one had already shown.
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v7
       - name: Setup MSVC Developer Command Prompt
         uses: ilammy/msvc-dev-cmd@v1
+      # tlsf.c does not include tlsf_thread.h, so none of the flags below
+      # change how it compiles, and every executable can link the same object.
+      # Compiling it once instead of once per executable is most of this job's
+      # build time.
+      - name: Compile TLSF Core with MSVC
+        run: |
+          cl.exe /c /Iinclude /O2 /W3 /std:c11 /DTLSF_ENABLE_ASSERT /DTLSF_ENABLE_CHECK src\tlsf.c /Fo:tlsf.obj
       - name: Compile Single-Threaded TLSF with MSVC
         run: |
-          cl.exe /Iinclude /O2 /W3 /std:c11 /DTLSF_ENABLE_ASSERT /DTLSF_ENABLE_CHECK src\tlsf.c tests\test.c /Fe:test_tlsf.exe
+          cl.exe /Iinclude /O2 /W3 /std:c11 /DTLSF_ENABLE_ASSERT /DTLSF_ENABLE_CHECK tests\test.c tlsf.obj /Fe:test_tlsf.exe
       - name: Run Single-Threaded Tests
         run: |
           .\test_tlsf.exe
       - name: Compile Multi-Threaded TLSF with MSVC (C11)
         run: |
-          cl.exe /Iinclude /O2 /W3 /std:c11 /DTLSF_ENABLE_ASSERT /DTLSF_ENABLE_CHECK /DTLSF_C11_THREADS src\tlsf.c src\tlsf_thread.c tests\test_thread.c /Fe:test_thread.exe
+          cl.exe /Iinclude /O2 /W3 /std:c11 /DTLSF_ENABLE_ASSERT /DTLSF_ENABLE_CHECK /DTLSF_C11_THREADS src\tlsf_thread.c tests\test_thread.c tlsf.obj /Fe:test_thread.exe
       - name: Run Multi-Threaded Tests
         run: |
           .\test_thread.exe
       - name: Compile Benchmark TLSF with MSVC
         run: |
-          cl.exe /Iinclude /O2 /W3 /std:c11 /DTLSF_ENABLE_ASSERT /DTLSF_ENABLE_CHECK src\tlsf.c tests\bench.c /Fe:bench_tlsf.exe /link Psapi.lib
+          cl.exe /Iinclude /O2 /W3 /std:c11 /DTLSF_ENABLE_ASSERT /DTLSF_ENABLE_CHECK tests\bench.c tlsf.obj /Fe:bench_tlsf.exe /link Psapi.lib
       - name: Run Benchmark TLSF
         run: |
           .\bench_tlsf.exe -l 10000 -i 3 -w 1
       - name: Compile WCET TLSF with MSVC
         run: |
-          cl.exe /Iinclude /O2 /W3 /std:c11 /DTLSF_ENABLE_ASSERT /DTLSF_ENABLE_CHECK src\tlsf.c tests\wcet.c /Fe:wcet_tlsf.exe
+          cl.exe /Iinclude /O2 /W3 /std:c11 /DTLSF_ENABLE_ASSERT /DTLSF_ENABLE_CHECK tests\wcet.c tlsf.obj /Fe:wcet_tlsf.exe
       - name: Run WCET TLSF
         run: |
           .\wcet_tlsf.exe -i 100 -w 10

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,17 @@ FRAMAC ?= frama-c
 # one: 'make verify' proves the helpers consistent with their own contracts,
 # not that the allocator establishes those contracts at the call sites. Extend
 # upward (block_split, block_absorb, block_set_free, ...) to close that gap.
+#
+# Read the goal count for what it is. This list is a subset of the functions
+# defined in src/tlsf.c, and tlsf_pool_reset is the only public entry point on
+# it. tlsf_malloc, tlsf_free, tlsf_realloc, tlsf_aalloc, tlsf_pool_init,
+# tlsf_append_pool, tlsf_usable_size, tlsf_check and tlsf_get_stats are all
+# unproved, as are the internal arena helpers they call.
+# Several listed helpers also have no postcondition, which means "proved" is
+# "cannot fault", not "returns the right answer": injecting a real bug into
+# align_offset still yields a fully proved run, while the same injection into
+# block_set_prev_free, which does carry 'ensures' clauses, is caught. A green
+# run here is a floor, not a certificate.
 WP_FUNCTIONS = \
 	align_up,align_ptr,block_payload,to_block,block_from_payload, \
 	block_is_free,block_is_prev_free,block_can_split,block_can_trim, \

--- a/include/tlsf.h
+++ b/include/tlsf.h
@@ -77,6 +77,11 @@ extern "C" {
  * TLSF_MAX_POOL_BITS=20 the largest accepted region is 524304 bytes, not 1 MB.
  * An unaligned pointer may carry up to ALIGN_SIZE-1 further bytes that are
  * skipped for alignment. TLSF_MAX_POOL_BYTES below states the limit.
+ *
+ * Give it a bare decimal literal. The ABI guard below pastes the value into the
+ * public symbol names, so a parenthesised or computed form such as (20) or (10
+ * + 10) does not form a valid identifier and fails to compile. The same applies
+ * to TLSF_ARENA_COUNT and TLSF_CACHELINE_SIZE in tlsf_thread.h.
  */
 #ifdef TLSF_MAX_POOL_BITS
 #define _TLSF_FL_MAX TLSF_MAX_POOL_BITS
@@ -96,6 +101,46 @@ extern "C" {
 #endif
 #define _TLSF_FL_COUNT (_TLSF_FL_MAX - _TLSF_FL_SHIFT + 1)
 #define TLSF_MAX_SIZE (((size_t) 1 << (_TLSF_FL_MAX - 1)) - sizeof(size_t))
+
+/* '_TLSF_SIZE_WIDTH' and every configuration macro that feeds '_TLSF_FL_MAX'
+ * change the layout of 'tlsf_t', which callers allocate themselves. A
+ * translation unit that disagrees with the library allocates the wrong size, so
+ * the first call writes past the end of the caller's object. Nothing diagnoses
+ * it: the link succeeds and the corruption surfaces later, somewhere else.
+ *
+ * Fold these values into the public symbol names so a disagreement becomes an
+ * undefined reference that names the value each side used. Source is unchanged,
+ * callers still write tlsf_malloc(); only the emitted symbol carries the
+ * suffix, which is what makes the mismatch visible to the linker.
+ *
+ * The cost is that the knobs must be bare decimal literals, since a token paste
+ * is what carries them into the name. That is narrower than the arithmetic the
+ * preprocessor would otherwise accept, and it is the one place this guard asks
+ * something of callers.
+ *
+ * Frama-C analyses one translation unit at a time, so it has no mismatch to
+ * catch, and the suffixed names would invalidate the '-wp-fct' list in the
+ * Makefile. Leave its view of the names alone.
+ */
+#ifndef __FRAMAC__
+#define _TLSF_ABI_PASTE(a, b) a##b
+#define _TLSF_ABI_EVAL(a, b) _TLSF_ABI_PASTE(a, b)
+#define _TLSF_ABI(name)                                        \
+    _TLSF_ABI_EVAL(_TLSF_ABI_EVAL(name##_w, _TLSF_SIZE_WIDTH), \
+                   _TLSF_ABI_EVAL(_fl, _TLSF_FL_MAX))
+
+#define tlsf_resize _TLSF_ABI(tlsf_resize)
+#define tlsf_aalloc _TLSF_ABI(tlsf_aalloc)
+#define tlsf_append_pool _TLSF_ABI(tlsf_append_pool)
+#define tlsf_pool_init _TLSF_ABI(tlsf_pool_init)
+#define tlsf_pool_reset _TLSF_ABI(tlsf_pool_reset)
+#define tlsf_malloc _TLSF_ABI(tlsf_malloc)
+#define tlsf_realloc _TLSF_ABI(tlsf_realloc)
+#define tlsf_free _TLSF_ABI(tlsf_free)
+#define tlsf_usable_size _TLSF_ABI(tlsf_usable_size)
+#define tlsf_check _TLSF_ABI(tlsf_check)
+#define tlsf_get_stats _TLSF_ABI(tlsf_get_stats)
+#endif
 
 /* Largest region tlsf_pool_init() accepts, for an ALIGN_SIZE-aligned pointer.
  * The pool's single initial free block cannot exceed 2^(_TLSF_FL_MAX - 1)
@@ -151,8 +196,8 @@ extern "C" {
 /* Everything the ladder above did not claim lands here: pre-C11 compilers,
  * pre-C++11 compilers, and a clang whose nested __has_extension test came out
  * false. That last case is why the fallback cannot be an '#else' arm of the
- * ladder; an '#elif' that a nested '#if' declines to fill would otherwise
- * leave the macro undefined.
+ * ladder; an '#elif' that a nested '#if' declines to fill would otherwise leave
+ * the macro undefined.
  */
 #ifndef TLSF_STATIC_ASSERT
 #define TLSF_SASSERT_GLUE(a, b) a##b
@@ -239,8 +284,9 @@ void *tlsf_resize(tlsf_t *t, size_t size);
  * @t : The TLSF allocator instance
  * @align : Alignment in bytes; must be a non-zero power of two
  * @size : Requested allocation size in bytes; need not be a multiple of @align
- * (follows POSIX posix_memalign semantics; C11 aligned_alloc required size %
- * align == 0 but C23 and common implementations dropped that constraint)
+ *         (follows POSIX posix_memalign semantics; C11 aligned_alloc required
+ *         size % align == 0 but C23 and common implementations dropped that
+ *         constraint)
  *
  * Return Pointer to at least @size bytes aligned to @align, or NULL on failure.
  * A zero @size request returns a unique minimum-sized allocation (consistent
@@ -328,7 +374,8 @@ void tlsf_pool_reset(tlsf_t *t);
  *
  * @t : The TLSF allocator instance
  * @size : Requested allocation size in bytes. A zero @size request returns a
- * unique minimum-sized allocation (POSIX-compatible behavior), not NULL.
+ *         unique minimum-sized allocation (POSIX-compatible behavior), not
+ *         NULL.
  *
  * Return Pointer to at least @size bytes, aligned to ALIGN_SIZE (8 on 64-bit, 4
  * on 32-bit), or NULL on failure.

--- a/include/tlsf_thread.h
+++ b/include/tlsf_thread.h
@@ -231,6 +231,53 @@ TLSF_STATIC_ASSERT(TLSF_ARENA_COUNT >= 1, "TLSF_ARENA_COUNT must be >= 1");
 TLSF_STATIC_ASSERT((TLSF_CACHELINE_SIZE & (TLSF_CACHELINE_SIZE - 1)) == 0,
                    "TLSF_CACHELINE_SIZE must be a power of two");
 
+/* Which lock backend was selected, not which macro the caller passed. The
+ * layout follows 'USE_C11_THREADS', and that is set either by TLSF_C11_THREADS
+ * or on Windows whenever the compiler supports C11 threads, so keying this off
+ * TLSF_C11_THREADS would both miss a real difference and invent one where the
+ * flag changes nothing. A caller-supplied TLSF_LOCK_T skips the whole
+ * selection, leaving this zero, which is why that case stays a caller
+ * obligation.
+ */
+#if defined(USE_C11_THREADS)
+#define _TLSF_THREAD_C11_THREADS 1
+#else
+#define _TLSF_THREAD_C11_THREADS 0
+#endif
+
+/* Same hazard as the core allocator, and the same remedy: 'tlsf_thread_t' is
+ * caller-allocated and its layout moves with TLSF_ARENA_COUNT,
+ * TLSF_CACHELINE_SIZE and the embedded 'tlsf_t', so a translation unit that
+ * disagrees about any of them corrupts the caller's object on the first call.
+ * The core ABI suffix plus the thread-specific knobs, including the C11-threads
+ * configuration, turn that into a link error. See the matching block in tlsf.h.
+ *
+ * A custom TLSF_LOCK_T also moves the layout and cannot be encoded in a token,
+ * so it stays a caller obligation: define it in one place every translation
+ * unit sees, the way the lock macros already have to be.
+ *
+ * _TLSF_ABI_EVAL comes from tlsf.h, included above, under the same __FRAMAC__
+ * condition. Keep the two guards identical: relaxing one alone leaves this
+ * block referring to a macro that no longer exists.
+ */
+#ifndef __FRAMAC__
+#define _TLSF_THREAD_ABI(name)                                                \
+    _TLSF_ABI_EVAL(                                                           \
+        _TLSF_ABI_EVAL(_TLSF_ABI(name), _TLSF_ABI_EVAL(a, TLSF_ARENA_COUNT)), \
+        _TLSF_ABI_EVAL(_TLSF_ABI_EVAL(c, TLSF_CACHELINE_SIZE),                \
+                       _TLSF_ABI_EVAL(t, _TLSF_THREAD_C11_THREADS)))
+
+#define tlsf_thread_init _TLSF_THREAD_ABI(tlsf_thread_init)
+#define tlsf_thread_destroy _TLSF_THREAD_ABI(tlsf_thread_destroy)
+#define tlsf_thread_malloc _TLSF_THREAD_ABI(tlsf_thread_malloc)
+#define tlsf_thread_aalloc _TLSF_THREAD_ABI(tlsf_thread_aalloc)
+#define tlsf_thread_realloc _TLSF_THREAD_ABI(tlsf_thread_realloc)
+#define tlsf_thread_free _TLSF_THREAD_ABI(tlsf_thread_free)
+#define tlsf_thread_check _TLSF_THREAD_ABI(tlsf_thread_check)
+#define tlsf_thread_stats _TLSF_THREAD_ABI(tlsf_thread_stats)
+#define tlsf_thread_reset _TLSF_THREAD_ABI(tlsf_thread_reset)
+#endif
+
 TLSF_MSVC_ALIGN(TLSF_CACHELINE_SIZE) typedef struct {
     tlsf_t pool;
     TLSF_LOCK_T lock;

--- a/src/tlsf.c
+++ b/src/tlsf.c
@@ -227,6 +227,7 @@ void *tlsf_resize_default(tlsf_t *t, size_t size)
     (void) size;
     return NULL;
 }
+
 /* The linker directive names the symbol as a string, and macros do not expand
  * inside a string literal, so it cannot spell 'tlsf_resize' directly: the ABI
  * guard in tlsf.h renames that to a configuration-suffixed symbol and the
@@ -799,8 +800,8 @@ INLINE void mapping(size_t size, uint32_t *fl, uint32_t *sl)
 /* The preconditions below mirror the runtime asserts and are what discharge the
  * shift and array-index obligations on 't->sl[*fl]' and '~0U << *sl'.
  *
- * Deliberately kept out of WP_FUNCTIONS: 35 of 36 goals prove, and the last one
- * is the bitmap_ffs precondition on line 'sl_map = t->sl[*fl]'. Proving it
+ * Deliberately kept out of WP_FUNCTIONS: every goal but one proves, and the
+ * holdout is the bitmap_ffs precondition on 'sl_map = t->sl[*fl]'. Proving it
  * needs the coherence invariant "a set bit in t->fl implies a nonzero
  * t->sl[i]", which in turn needs a postcondition relating bitmap_ffs to the bit
  * it found. bitmap_ffs is __builtin_ctz here, and Alt-Ergo does not discharge
@@ -1391,8 +1392,8 @@ INLINE tlsf_block_t *block_find_free(tlsf_t *t, size_t *size)
     }
 
     /* *size stays at the rounded request. round_block_size() above already put
-     * it exactly on a bin boundary, which is what issue #4 requires: a freed
-     * block lands in the bin a same-size request will search.
+     * it exactly on a bin boundary, which is what bin-boundary reuse requires:
+     * a freed block lands in the bin a same-size request will search.
      *
      * Do NOT substitute mapping_size(fl, sl) here. block_find_suitable() may
      * return a block from a LARGER bin than the request maps to, and inflating

--- a/src/tlsf.c
+++ b/src/tlsf.c
@@ -1712,7 +1712,7 @@ void tlsf_check(tlsf_t *t)
 
         /* Size invariants */
         CHECK(bsize >= BLOCK_SIZE_MIN, "block smaller than minimum size");
-        CHECK(bsize <= BLOCK_SIZE_MAX, "block exceeds maximum size");
+        CHECK(bsize < (size_t) 1 << FL_MAX, "block exceeds mapping range");
         CHECK(bsize % ALIGN_SIZE == 0, "block size not aligned");
 
         /* Pointer alignment check */

--- a/src/tlsf.c
+++ b/src/tlsf.c
@@ -227,11 +227,29 @@ void *tlsf_resize_default(tlsf_t *t, size_t size)
     (void) size;
     return NULL;
 }
+/* The linker directive names the symbol as a string, and macros do not expand
+ * inside a string literal, so it cannot spell 'tlsf_resize' directly: the ABI
+ * guard in tlsf.h renames that to a configuration-suffixed symbol and the
+ * fallback would bind to a name nothing defines. Stringify the expansion
+ * instead, and build the pragma through __pragma so the whole directive can
+ * come from a macro. The fallback target keeps its plain name because it is
+ * defined here rather than declared in the public header.
+ */
+#define TLSF_STRINGIFY_(x) #x
+#define TLSF_STRINGIFY(x) TLSF_STRINGIFY_(x)
+#define TLSF_LINKER_COMMENT_(x) __pragma(comment(linker, x))
 #if defined(_M_IX86)
-#pragma comment(linker, "/alternatename:_tlsf_resize=_tlsf_resize_default")
+#define TLSF_RESIZE_ALTERNATENAME \
+    "/alternatename:_" TLSF_STRINGIFY(tlsf_resize) "=_tlsf_resize_default"
 #else
-#pragma comment(linker, "/alternatename:tlsf_resize=tlsf_resize_default")
+#define TLSF_RESIZE_ALTERNATENAME \
+    "/alternatename:" TLSF_STRINGIFY(tlsf_resize) "=tlsf_resize_default"
 #endif
+TLSF_LINKER_COMMENT_(TLSF_RESIZE_ALTERNATENAME)
+#undef TLSF_RESIZE_ALTERNATENAME
+#undef TLSF_LINKER_COMMENT_
+#undef TLSF_STRINGIFY
+#undef TLSF_STRINGIFY_
 #endif
 
 /*@

--- a/src/tlsf.c
+++ b/src/tlsf.c
@@ -444,7 +444,11 @@ INLINE void block_set_prev_free(tlsf_block_t *block, bool free)
                     (free ? BLOCK_BIT_PREV_FREE : 0);
 }
 
-/*@ assigns \nothing; */
+/*@
+  requires align > 0;
+  requires (align & (align - 1)) == 0;
+  assigns \nothing;
+*/
 INLINE size_t align_up(size_t x, size_t align)
 {
     ASSERT(align, "alignment must be non-zero");
@@ -564,6 +568,7 @@ INLINE tlsf_block_t *block_prev(const tlsf_block_t *block)
 /*@
   requires tlsf_next_header_span(block);
   requires tlsf_aligned_header(block);
+  requires block->header - block->header % ALIGN_SIZE >= BLOCK_OVERHEAD;
   assigns \result \from block, block->header;
 */
 INLINE tlsf_block_t *block_next(tlsf_block_t *block)
@@ -702,6 +707,8 @@ INLINE void block_set_free(tlsf_block_t *block, bool free)
  * bypassing subsequent TLSF_MAX_SIZE checks.
  */
 /*@
+  requires align > 0;
+  requires (align & (align - 1)) == 0;
   assigns \nothing;
   ensures size > TLSF_MAX_SIZE ==> \result == size;
 */

--- a/tests/pool_limits.h
+++ b/tests/pool_limits.h
@@ -43,6 +43,19 @@
 #define TLSF_TEST_BLOCK_COST \
     (sizeof(struct tlsf_block) - sizeof(struct tlsf_block *) + sizeof(size_t))
 
+/* The minimum remainder tlsf leaves when it trims a block, mirroring the
+ * library default at the top of src/tlsf.c. The macro is internal there, so a
+ * fixture that has to know whether a trim is possible at all must recompute it.
+ * An override reaches both translation units through CPPFLAGS, so honor it when
+ * present rather than assuming the default.
+ */
+#ifdef TLSF_SPLIT_THRESHOLD
+#define TLSF_TEST_SPLIT_THRESHOLD ((size_t) (TLSF_SPLIT_THRESHOLD))
+#else
+#define TLSF_TEST_SPLIT_THRESHOLD \
+    (sizeof(struct tlsf_block) - sizeof(struct tlsf_block *))
+#endif
+
 /* Ceiling on what a fixture may ask the host for in one go. Several tests are
  * only meaningful near a configuration limit that scales with
  * TLSF_MAX_POOL_BITS, which at the default is far past any allocation that

--- a/tests/pool_limits.h
+++ b/tests/pool_limits.h
@@ -43,6 +43,22 @@
 #define TLSF_TEST_BLOCK_COST \
     (sizeof(struct tlsf_block) - sizeof(struct tlsf_block *) + sizeof(size_t))
 
+/* Ceiling on what a fixture may ask the host for in one go. Several tests are
+ * only meaningful near a configuration limit that scales with
+ * TLSF_MAX_POOL_BITS, which at the default is far past any allocation that
+ * would succeed. They compare their requirement against this and skip with a
+ * reason instead of failing, so a default build stays quiet and a reduced-
+ * ceiling build actually exercises them.
+ */
+#define TLSF_TEST_BACKABLE_MAX ((size_t) 64 << 20)
+
+/* Largest block a single allocation can ever occupy: the biggest request plus
+ * its header. src/tlsf.c static-asserts this equals BLOCK_SIZE_MAX. A free
+ * block may legitimately exceed it after coalescing, which is exactly what the
+ * fixtures that use this constant are there to pin down.
+ */
+#define TLSF_TEST_ALLOC_BOUND (TLSF_MAX_SIZE + sizeof(size_t))
+
 /* Clamp a desired pool size to what this configuration accepts. Usable as an
  * array bound: both operands are integer constant expressions.
  */

--- a/tests/test.c
+++ b/tests/test.c
@@ -1295,11 +1295,11 @@ static void oversized_free_block_test(void)
            stats.largest_free, (size_t) TLSF_TEST_ALLOC_BOUND);
 }
 
-/* Issue #4: a freed block must land in the bin that a same-size request will
- * search, so free-then-reallocate at the same size reuses the same address.
- * Guards against a future change that searches with the rounded size but stores
- * the block at the unrounded one. The block under test is sandwiched between
- * live allocations so it cannot coalesce and mask the result.
+/* A freed block must land in the bin that a same-size request will search, so
+ * free-then-reallocate at the same size reuses the same address. Guards against
+ * a future change that searches with the rounded size but stores the block at
+ * the unrounded one. The block under test is sandwiched between live
+ * allocations so it cannot coalesce and mask the result.
  */
 static void reuse_same_address_test(void)
 {

--- a/tests/test.c
+++ b/tests/test.c
@@ -1107,6 +1107,29 @@ static void small_bin_trim_test(void)
     tlsf_free(&t, big);
     tlsf_check(&t);
 
+    /* A minimal request can only trim this block if what is left over clears
+     * the split threshold. Configure that threshold near the top of the FL=0
+     * range and the allocator correctly refuses to split anything in it, so
+     * there is no trim to measure and the assertions below would be testing the
+     * configuration rather than the fast path. Skip loudly instead of failing:
+     * the library is behaving as configured.
+     *
+     * The bound is deliberately conservative rather than exact. Predicting the
+     * split decision needs the block size the fast path actually found, which
+     * may be larger than the seed after coalescing, so an exact bound derived
+     * from 'seeded' alone gets it wrong near the boundary. Over-skipping costs
+     * a narrow band of coverage; under-skipping turns a correct library into a
+     * failing test, which is worse.
+     */
+    if (TLSF_TEST_SPLIT_THRESHOLD > seeded - TLSF_TEST_BLOCK_COST) {
+        printf(
+            "skipped (split threshold %zu leaves no trimmable remainder "
+            "in a %zu-byte FL=0 block)\n",
+            (size_t) TLSF_TEST_SPLIT_THRESHOLD, seeded);
+        tlsf_free(&t, guard);
+        return;
+    }
+
     /* A minimal request must not swallow the seeded block. */
     void *probe = tlsf_malloc(&t, 1);
     assert(probe);

--- a/tests/test.c
+++ b/tests/test.c
@@ -1135,7 +1135,7 @@ static void pool_ceiling_test(void)
     printf("Pool ceiling test: ");
     fflush(stdout);
 
-    if (TLSF_MAX_POOL_BYTES > (size_t) 64 << 20) {
+    if (TLSF_MAX_POOL_BYTES > TLSF_TEST_BACKABLE_MAX) {
         printf(
             "skipped (ceiling %zu bytes exceeds what we can allocate; "
             "build with -DTLSF_MAX_POOL_BITS=24 or less to cover it)\n",
@@ -1160,6 +1160,116 @@ static void pool_ceiling_test(void)
     free(mem);
     printf("%zu accepted, +%zu rejected\n", (size_t) TLSF_MAX_POOL_BYTES,
            align);
+}
+
+/* A coalesced free block may exceed BLOCK_SIZE_MAX, which bounds a single
+ * allocation. The structural cap is the arena ceiling of 2^_TLSF_FL_MAX, what
+ * the mapping function can index, so a heap check that reused the allocation
+ * bound aborted on a perfectly healthy heap.
+ *
+ * This is the route that needs no fixed pool and no append, only coalescing.
+ * Two large neighbours freed back to back merge into one block above the
+ * allocation bound. A third live allocation past them keeps the merge away from
+ * the sentinel, which would otherwise route the run to arena_shrink() and hide
+ * it. Shares the caller's dynamic arena because tlsf_resize() here hands every
+ * instance the same region.
+ */
+static void coalesced_free_block_test(tlsf_t *t)
+{
+    printf("Coalesced free block test: ");
+    fflush(stdout);
+
+    const size_t bound = TLSF_TEST_ALLOC_BOUND;
+
+    /* Three quarters each, so the two together clear the bound once merged
+     * while both still fit under the arena ceiling of twice the bound.
+     */
+    const size_t each = bound - bound / 4;
+
+    /* Guard on what this actually asks for, half again the bound, not on the
+     * bound itself. The two neighbours plus the pin are the whole demand, and
+     * checking only the bound would let the largest accepted configuration
+     * request half again the ceiling and turn resource pressure into a failed
+     * assertion instead of a skip.
+     */
+    const size_t needed = 2 * each + TLSF_TEST_BLOCK_COST;
+    if (needed > TLSF_TEST_BACKABLE_MAX) {
+        printf("skipped (needs %zu bytes, beyond what we can back)\n", needed);
+        return;
+    }
+
+    void *a = tlsf_malloc(t, each);
+    void *b = tlsf_malloc(t, each);
+    void *pin = tlsf_malloc(t, 24);
+    assert(a && b && pin);
+    tlsf_check(t);
+
+    tlsf_free(t, a);
+    tlsf_free(t, b);
+
+    /* Without the merge clearing the bound this test proves nothing, so say so
+     * rather than passing quietly.
+     */
+    tlsf_stats_t stats;
+    assert(tlsf_get_stats(t, &stats) == 0);
+    assert(stats.largest_free > bound);
+
+    tlsf_check(t);
+
+    tlsf_free(t, pin);
+    tlsf_check(t);
+
+    printf("%zu-byte block from coalescing, above the %zu-byte bound, done\n",
+           stats.largest_free, bound);
+}
+
+/* The same defect by a second route: appending to a pool already at the
+ * published fixed-pool ceiling merges the two spans into one free block above
+ * the allocation bound. Uses a fixed pool, so it is independent of the dynamic
+ * arena the coalescing route above exercises.
+ */
+static void oversized_free_block_test(void)
+{
+    printf("Oversized free block test: ");
+    fflush(stdout);
+
+    const size_t ceiling = (size_t) 1 << _TLSF_FL_MAX;
+    if (ceiling > TLSF_TEST_BACKABLE_MAX) {
+        printf(
+            "skipped (arena ceiling %zu bytes exceeds what we can allocate)\n",
+            ceiling);
+        return;
+    }
+
+    /* pool_init takes the published ceiling; the append takes the rest, so the
+     * two spans together are exactly the arena ceiling.
+     */
+    char *mem = (char *) malloc(ceiling);
+    assert(mem);
+    assert((size_t) mem % sizeof(void *) == 0); /* else adj shifts the split */
+
+    tlsf_t t;
+    size_t seeded = tlsf_pool_init(&t, mem, TLSF_MAX_POOL_BYTES);
+    assert(seeded > 0);
+
+    size_t added = tlsf_append_pool(&t, mem + TLSF_MAX_POOL_BYTES,
+                                    ceiling - TLSF_MAX_POOL_BYTES);
+    assert(added > 0);
+
+    /* The point of the test: one free block, larger than any single allocation
+     * may be, still below what the mapping function can index.
+     */
+    tlsf_stats_t stats;
+    assert(tlsf_get_stats(&t, &stats) == 0);
+    assert(stats.free_count == 1);
+    assert(stats.largest_free > TLSF_TEST_ALLOC_BOUND);
+    assert(stats.largest_free < ceiling);
+
+    tlsf_check(&t);
+
+    free(mem);
+    printf("%zu-byte free block above the %zu-byte allocation bound, done\n",
+           stats.largest_free, (size_t) TLSF_TEST_ALLOC_BOUND);
 }
 
 /* Issue #4: a freed block must land in the bin that a same-size request will
@@ -1361,6 +1471,8 @@ int main(void)
 
     /* Run pool ceiling test */
     pool_ceiling_test();
+    oversized_free_block_test();
+    coalesced_free_block_test(&t);
 
     puts("OK!");
     return 0;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Turns a TLSF configuration mismatch into a link error instead of silent heap corruption, and fixes `tlsf_check()` aborting on healthy heaps. `tlsf_t` and `tlsf_thread_t` are caller-allocated and their layout moves with config macros, so a caller built with different knobs than the library used to link cleanly and write past the caller's object.

**ABI guard**
- Config values are token-pasted into public symbol names (`tlsf_malloc_w64_fl23`), so a mismatch becomes an undefined reference that names the value on each side.
- The knobs must now be bare decimal literals, and `dlsym`/FFI callers must use the suffixed names.
- The thread suffix encodes the lock backend from `USE_C11_THREADS`, the actually-selected macro rather than `TLSF_C11_THREADS`, so a lock-type disagreement in either direction fails to link.
- Frama-C is exempted from the rename; the MSVC `tlsf_resize` fallback now follows it.
- CI checks that mismatched pairs fail to link and matched pairs still link and run; the MSVC job now compiles `tlsf.c` once for all four executables.

**Bug fixes**
- `tlsf_check()` now bounds blocks by the mapping range `2^FL_MAX` instead of the per-allocation `BLOCK_SIZE_MAX`, which coalescing and arena growth legitimately exceed.
- New fixtures pin both oversized-block routes through `tlsf_get_stats()` and skip when the host can't back their demand; the coalescing fixture checks its real demand, not the bound.
- `small_bin_trim_test` skips loudly when `TLSF_SPLIT_THRESHOLD` makes trimming impossible.
- `make verify` gains the missing `align_up`, `adjust_size`, and `block_next` clauses; the `WP_FUNCTIONS` comment now names the unproved entry points and states that a green run is not a correctness certificate.

<sup>Written for commit 54c7d07bb5edd5365631d85c023a6c367a2c331e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/tlsf-bsd/pull/38?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

