### PR TITLE
Make C and C++ agree on the thread wrapper ABI

### DIFF
--- a/.ci/check-abi-guard.sh
+++ b/.ci/check-abi-guard.sh
@@ -101,11 +101,16 @@ check links "" thread "thread: matched configuration"
 check fails "-DTLSF_ARENA_COUNT=8" thread "thread: TLSF_ARENA_COUNT mismatch"
 check fails "-DTLSF_CACHELINE_SIZE=128" thread "thread: TLSF_CACHELINE_SIZE mismatch"
 
+# The wrapper spells the core half of the suffix itself rather than wrapping
+# _TLSF_ABI, so a core knob added to one and not the other would go unnoticed:
+# the wrapper stays self-consistent, links, and silently stops tracking a knob
+# that still moves the embedded 'tlsf_t'. Check a core knob on this target too.
+check fails "-DTLSF_MAX_POOL_BITS=20" thread "thread: TLSF_MAX_POOL_BITS mismatch"
+
 # TLSF_C11_THREADS does not decide the lock backend on its own. The header
-# selects on USE_C11_THREADS, which needs the compiler to actually have C11
-# threads and is also set on Windows without the flag, so whether the flag
-# changes anything is a property of the host. Ask the header which backend it
-# picked rather than inferring it.
+# selects on _TLSF_USE_C11_THREADS, which also needs the compiler to have a usable
+# '<threads.h>', so whether the flag changes anything is a property of the host.
+# Ask the header which backend it picked rather than inferring it.
 #
 # Do not infer it from sizeof either. On glibc, mtx_t and pthread_mutex_t are
 # the same size, so the wrapper measures identical while the lock operations
@@ -116,7 +121,7 @@ cat >"$tmp/backend.c" <<'EOF'
 #include "tlsf_thread.h"
 int main(void)
 {
-	printf("%d\n", _TLSF_THREAD_C11_THREADS);
+	printf("%d\n", _TLSF_THREAD_BACKEND);
 	return 0;
 }
 EOF
@@ -135,6 +140,69 @@ if [ "$plain" = "$c11" ]; then
 else
 	check fails "-DTLSF_C11_THREADS" thread \
 		"thread: TLSF_C11_THREADS mismatch"
+fi
+
+# The two Windows natives are the pair no build system chooses between: the
+# header picks from '_WIN32_WINNT' and the compiler version, both of which a
+# caller can set per translation unit, while 'SRWLOCK' is one pointer and
+# 'CRITICAL_SECTION' is 40 bytes on x86-64. A boolean C11-or-not suffix gave
+# both the same name, so a mismatched pair linked and then read 'base' and
+# 'capacity' at each other's offsets. Not at a different arena stride: 32 bytes
+# fit inside the cache-line padding, so both give the same
+# 'sizeof(tlsf_thread_t)', which is also why measuring is no substitute for this
+# check. Nothing here can link Windows code, so drive each arm through the
+# preprocessor alone against an empty 'windows.h' and require two distinct
+# names.
+#
+# Names, not the '_TLSF_THREAD_BACKEND' ids behind them. The id is the input to
+# the paste and the name is what the linker matches on, so comparing ids would
+# still pass if the paste stopped consuming the id, which is the one edit that
+# would bring the shared-suffix bug back. Ask for the expansion of
+# 'tlsf_thread_init' and compare that.
+#
+# The header reaches SRWLOCK by four routes, and only the '_WIN32_WINNT' one is
+# under this script's control. The other three key off the host compiler, so
+# they answer the same on both invocations and would collapse the low arm onto
+# the high one: undefine what identifies clang and MinGW, or the check reports a
+# failure on an MSYS2 host and proves nothing on any host.
+mkdir -p "$tmp/winstub"
+: >"$tmp/winstub/windows.h"
+
+cat >"$tmp/win_backend.c" <<'EOF'
+#include "tlsf_thread.h"
+NAME tlsf_thread_init
+EOF
+
+# Swallowing the preprocessor's exit status, not its diagnostics: those still
+# reach the job log. A directive the header rejects under these defines would
+# otherwise take 'set -e' out through the command substitution below, ending the
+# script on a bare status with none of the checks reported. A failure here has to
+# print its FAIL line like every other check, which is what the empty-value
+# default below is for.
+win_symbol() {
+	# shellcheck disable=SC2086
+	$CC -Iinclude -I"$tmp/winstub" -std=gnu11 -D_WIN32 \
+		-U__clang__ -U__MINGW32__ -U__MINGW64__ "$@" \
+		-E -P "$tmp/win_backend.c" | sed -n 's/^NAME //p' || true
+}
+
+srwlock="$(win_symbol -D_WIN32_WINNT=0x0600)"
+crsection="$(win_symbol -D_WIN32_WINNT=0x0501)"
+
+# Both names have to be there before comparing them, since a probe that failed
+# yields an empty one and empty differs from everything. An unsuffixed name is
+# the other way to pass without meaning it: the renaming did not happen at all,
+# which is a shared suffix by another route.
+if [ -n "$srwlock" ] && [ -n "$crsection" ] &&
+	[ "$srwlock" != "tlsf_thread_init" ] &&
+	[ "$crsection" != "tlsf_thread_init" ] &&
+	[ "$srwlock" != "$crsection" ]; then
+	echo "ok: thread: SRWLOCK and CRITICAL_SECTION differ" \
+		"($srwlock vs $crsection)"
+else
+	echo "FAIL: thread: Windows lock backends share a symbol name" \
+		"($srwlock vs $crsection)"
+	ret=1
 fi
 
 exit $ret

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,15 @@ jobs:
           - runner: ubuntu-24.04
             cc: gcc
             cflags: "-DTLSF_SPLIT_THRESHOLD=64"
+          # C11 threads reaching both languages at once. 'make check' links
+          # tests/test_cpp.cpp against the same src/tlsf_thread.c object, so the
+          # C and the C++ unit have to select the same lock backend from the
+          # same flag. Before the C++ arm of that selection existed this entry
+          # failed to link, which is issue #40 spelled in glibc rather than
+          # MSVC. glibc has had '<threads.h>' since 2.28.
+          - runner: ubuntu-24.04
+            cc: gcc
+            cflags: "-DTLSF_C11_THREADS"
           # Release configuration. NDEBUG covers libc assert(); clearing
           # TLSF_DEBUG_FLAGS covers the library's own knobs, which are on for
           # every other entry, so this is the only job that compiles the empty
@@ -257,6 +266,59 @@ jobs:
       - name: Run Multi-Threaded Tests
         run: |
           .\test_thread.exe
+      # Neither step below passes /DTLSF_C11_THREADS, and that is the test: the
+      # C unit and the C++ unit have to agree on the lock backend and on the
+      # token paste, or the link fails on an unresolved 'tlsf_thread_*' symbol.
+      # Reverting either half of the fix fails here. This pair is also the only
+      # place MSVC's two preprocessors meet, since /std:c11 implies
+      # /Zc:preprocessor and /std:c++14 does not.
+      #
+      # The wrapper compiles in its own step because a step reports the exit
+      # status of its last command only, which would hide a failed compile and
+      # link the stale object left by the C11 step above.
+      - name: Compile Thread Wrapper for the C++ Link
+        run: |
+          cl.exe /c /Iinclude /O2 /W3 /we4146 /we4334 /std:c11 /DTLSF_ENABLE_ASSERT /DTLSF_ENABLE_CHECK src\tlsf_thread.c /Fo:tlsf_thread.obj
+      - name: Compile C++ TLSF Test with MSVC
+        run: |
+          cl.exe /Iinclude /O2 /W3 /we4146 /we4334 /std:c++14 /DTLSF_ENABLE_ASSERT /DTLSF_ENABLE_CHECK tests\test_cpp.cpp tlsf.obj tlsf_thread.obj /Fe:test_cpp.exe
+      - name: Run C++ TLSF Test
+        run: |
+          .\test_cpp.exe
+      # The same pair with the flag on both units, which is what the reporter
+      # of issue #40 was after. MSVC ships '<threads.h>' from 17.8 on, so the
+      # C++ unit finds it through __has_include and has to land on the same
+      # 'mtx_t' layout the C unit picked. This is also the only check that MSVC
+      # can preprocess and compile that header outside C mode at all; if it
+      # cannot, the C++ arm of the selection has to go back to declining.
+      #
+      # /std:c++14 is MSVC's default and the mode a user reaches without asking,
+      # so it is the one worth testing. It reaches 'mtx_t' through the C++ arm's
+      # __has_include probe; the version fallback beside that probe is not
+      # exercised here and is not expected to be, see the header.
+      - name: Compile Thread Wrapper for the C++ C11 Link
+        run: |
+          cl.exe /c /Iinclude /O2 /W3 /we4146 /we4334 /std:c11 /DTLSF_ENABLE_ASSERT /DTLSF_ENABLE_CHECK /DTLSF_C11_THREADS src\tlsf_thread.c /Fo:tlsf_thread_c11.obj
+      - name: Compile C++ TLSF Test with MSVC (C11)
+        run: |
+          cl.exe /Iinclude /O2 /W3 /we4146 /we4334 /std:c++14 /DTLSF_ENABLE_ASSERT /DTLSF_ENABLE_CHECK /DTLSF_C11_THREADS tests\test_cpp.cpp tlsf.obj tlsf_thread_c11.obj /Fe:test_cpp_c11.exe
+      - name: Run C++ TLSF Test (C11)
+        run: |
+          .\test_cpp_c11.exe
+      # The stress test on the lock a Windows user now gets without asking.
+      # Until the selection above changed, every MSVC build reached 'mtx_t'
+      # whether or not it asked for it, so 'SRWLOCK' was unreachable and went
+      # unrun; it is the default from here on. The C++ steps compile it but call
+      # the wrapper once each on one thread, so nothing else in this job would
+      # notice a wrong polarity in TLSF_LOCK_TRY or an acquire paired with the
+      # wrong release. Last of the wrapper steps because it recompiles
+      # 'tlsf_thread.obj' in the working directory as a side effect.
+      - name: Compile Multi-Threaded TLSF with MSVC (native lock)
+        run: |
+          cl.exe /Iinclude /O2 /W3 /we4146 /we4334 /std:c11 /DTLSF_ENABLE_ASSERT /DTLSF_ENABLE_CHECK src\tlsf_thread.c tests\test_thread.c tlsf.obj /Fe:test_thread_native.exe
+      - name: Run Multi-Threaded Tests (native lock)
+        run: |
+          .\test_thread_native.exe
       - name: Compile Benchmark TLSF with MSVC
         run: |
           cl.exe /Iinclude /O2 /W3 /we4146 /we4334 /std:c11 /DTLSF_ENABLE_ASSERT /DTLSF_ENABLE_CHECK tests\bench.c tlsf.obj /Fe:bench_tlsf.exe /link Psapi.lib

--- a/README.md
+++ b/README.md
@@ -181,14 +181,14 @@ tlsf_thread_destroy(&ts);
 
 `TLSF_ARENA_COUNT` is the arena count, four by default, and a ceiling rather
 than a promise: `tlsf_thread_init()` halves it while the per-arena share would
-fall below 256 bytes. The lock
-backend is chosen by the header: C11 `mtx_t` on Windows whenever `<threads.h>`
-is available and elsewhere when `TLSF_C11_THREADS` asks for it, Win32 `SRWLOCK`
-or `CRITICAL_SECTION` on Windows otherwise, `pthread_mutex_t` everywhere else.
-For a platform-specific lock (FreeRTOS semaphore, Zephyr k_mutex, bare-metal
-spinlock), define `TLSF_LOCK_T` and the five lock macros before including
-`tlsf_thread.h`; that bypasses the selection, so matching the backend across
-translation units becomes the caller's obligation.
+fall below 256 bytes. The lock backend is chosen by the header: C11 `mtx_t`
+when `TLSF_C11_THREADS` asks for it and `<threads.h>` is available, Win32
+`SRWLOCK` or `CRITICAL_SECTION` on Windows otherwise, `pthread_mutex_t`
+everywhere else; see [Lock backends](docs/operations.md#lock-backends) for the
+migration note. For a platform-specific lock (FreeRTOS semaphore, Zephyr
+k_mutex, bare-metal spinlock), define `TLSF_LOCK_T` and the five lock macros
+before including `tlsf_thread.h`; that bypasses the selection, so matching the
+backend across translation units becomes the caller's obligation.
 
 The full knob list is in
 [Thread wrapper flags](docs/configuration-and-verification.md#thread-wrapper-flags),

--- a/docs/configuration-and-verification.md
+++ b/docs/configuration-and-verification.md
@@ -58,7 +58,7 @@ is always a legal block, and at most `BLOCK_SIZE_MAX`, so the arithmetic in
 |------|---------|--------|
 | `TLSF_ARENA_COUNT` | 4 | Independent sub-pools, each with its own lock |
 | `TLSF_CACHELINE_SIZE` | 64 | Per-arena padding, must be a power of two |
-| `TLSF_C11_THREADS` | off | Prefer the C11 `<threads.h>` backend where available |
+| `TLSF_C11_THREADS` | off | The C11 `<threads.h>` backend, where available |
 | `TLSF_LOCK_T` plus five macros | platform default | A caller-supplied lock backend |
 | `TLSF_THREAD_HINT()` | platform thread id | Hash input for arena selection |
 
@@ -137,13 +137,17 @@ Undefined symbols for architecture arm64:
 ```
 
 `w64` is `_TLSF_SIZE_WIDTH`, `fl20` is `_TLSF_FL_MAX`. The thread wrapper adds
-its own tags for `TLSF_ARENA_COUNT`, `TLSF_CACHELINE_SIZE` and whether the C11
-threads backend was selected.
+its own tags for `TLSF_ARENA_COUNT`, `TLSF_CACHELINE_SIZE` and which lock
+backend the header selected.
 
-That last tag is a single bit, so it catches a C11-versus-native disagreement but
-not `SRWLOCK` versus `CRITICAL_SECTION`, and not a caller-supplied
-`TLSF_LOCK_T`. Those change `sizeof(TLSF_LOCK_T)` and therefore the arena
-stride, and they remain a caller obligation.
+That last tag names the backend rather than recording C11-or-not, so it covers
+`SRWLOCK` versus `CRITICAL_SECTION` too, the pair no build flag chooses between.
+A caller-supplied `TLSF_LOCK_T` stays outside it: the header makes no selection
+to record, while the lock type still moves the fields stored behind it in each
+arena, so that one remains a caller obligation. Do not reach for `sizeof` in its
+place. The cache-line padding hides a lock-size change from the arena stride
+until it crosses a whole line, so two incompatible builds usually measure the
+same.
 
 Four consequences worth knowing:
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -319,7 +319,7 @@ in this order:
 | Condition | Backend |
 |-----------|---------|
 | `TLSF_LOCK_T` already defined by the caller | whatever the caller supplied |
-| Windows with C11 threads available, or `TLSF_C11_THREADS` with C11 threads available | C11 `mtx_t` |
+| `TLSF_C11_THREADS` with C11 threads available | C11 `mtx_t` |
 | Windows, `_WIN32_WINNT >= 0x0600` or a compiler new enough to imply it | `SRWLOCK` |
 | Windows, older | `CRITICAL_SECTION` |
 | POSIX: `__unix__`, `__APPLE__`, `__linux__` and friends | `pthread_mutex_t` |
@@ -330,11 +330,48 @@ is the bare-metal and RTOS case this section is about, must supply
 `TLSF_LOCK_T` itself; without it the arena structure has no lock member and the
 build fails at the struct definition rather than at link time.
 
-Note the first Windows row: `TLSF_C11_THREADS` is not required there. A MinGW or
-clang build with `<threads.h>` picks C11 threads on its own, and on MSVC the
-macro is required only because MSVC gates its own C11 thread support behind it.
-That is why the ABI guard keys off the backend actually selected rather than off
-the flag.
+Keeping the Windows default at the native lock is what makes C and C++
+translation units select the same backend; the ABI guard still rejects a
+backend mismatch. It encodes which of the four the header landed on, not
+whether C11 threads were asked for, so the pair no build system chooses between
+is covered too: `_WIN32_WINNT` is settable per translation unit, and an
+`SRWLOCK` build mixed with a `CRITICAL_SECTION` one puts `base` and `capacity`
+at different offsets inside every arena and hands storage prepared by
+`InitializeSRWLock` to `EnterCriticalSection`. Sizes are no guide here. The
+cache-line alignment absorbs the 32-byte difference between those two locks, so
+`sizeof(tlsf_thread_t)` comes out identical either way, and `mtx_t` and
+`pthread_mutex_t` are the same size on glibc to begin with.
+
+Windows builds that used to reach `mtx_t` without asking now get the native lock
+instead. That is every C build with a usable `<threads.h>`, MinGW and clang but
+also MSVC under `/std:c11`: MSVC never defines `__STDC_NO_THREADS__`, so the old
+test could not tell a compiler that has C11 threads from one that does not.
+Rebuilding everything is enough, and a partial rebuild fails to link rather than
+silently disagreeing about the layout of `tlsf_thread_t`.
+
+`TLSF_C11_THREADS` brings `mtx_t` back, in C++ as much as in C. Nothing forbids
+a C++ unit from using the C11 header; the two languages simply establish that it
+is there by different means. C reads `__STDC_VERSION__`, which C++ does not
+define, so the C++ arm probes with `__has_include` instead. GCC and clang offer
+that probe in every mode, not only C++17. Where it is missing, which in practice
+means an older MSVC C++ mode, the arm falls back to the same 17.8 version test
+the C side uses, so the two languages still agree.
+
+`__STDC_NO_THREADS__` is checked once, before that split, and a compiler that
+defines it gets taken at its word in either language. The name is misleading:
+clang defines it in C++ mode, and defines it for its MSVC targets in both
+languages, so clang-cl declines the C11 backend even where the toolset ships
+`<threads.h>`. Consistency is worth more here than reach, since the alternative
+is clang-cl selecting `mtx_t` from C and `SRWLOCK` from C++ off one flag.
+
+One combination still splits them, a C library that sets `__STDC_NO_THREADS__`
+while shipping the header anyway, read by a compiler that offers no such macro
+to C++. C declines, C++ accepts. The ABI suffix makes that a link error as soon
+as the C++ side calls a wrapper function, which is the useful half of the
+answer. It is not a complete net: a C++ unit that only embeds `tlsf_thread_t` in
+a structure, or takes its size, and leaves every call to C emits nothing for the
+linker to catch, and the two layouts disagree in silence. On such a toolchain,
+mixing the two languages means leaving the flag off.
 
 Porting to an RTOS means defining `TLSF_LOCK_T`, the five lock macros, and
 `TLSF_THREAD_HINT()` before including the header. The header's own example is

--- a/include/tlsf.h
+++ b/include/tlsf.h
@@ -9,14 +9,17 @@
 
 #pragma once
 
-/* Inhibit C++ name-mangling for tlsf functions */
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+
+/* Inhibit C++ name-mangling for tlsf functions. Opened after the includes, for
+ * the reason tlsf_thread.h gives at its own block: a system header compiled
+ * inside a language linkage it never declared is not the library's to promise.
+ */
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 /* IMPORTANT: the configuration macros below (TLSF_MAX_POOL_BITS in particular)
  * change the layout and size of tlsf_t, which callers allocate themselves.
@@ -118,16 +121,24 @@ extern "C" {
  * preprocessor would otherwise accept, and it is the one place this guard asks
  * something of callers.
  *
+ * The paste is one flat '##' chain: _TLSF_ABI_EVAL expands the value macros,
+ * _TLSF_ABI_PASTE glues them, and an argument next to '##' is not expanded, so
+ * the levels cannot collapse. Never nest one paste inside another. MSVC's
+ * traditional and '/Zc:preprocessor' rescans spell that differently, and
+ * '/std:c11' turns the latter on while the C++ modes leave it opt-in, so a
+ * mixed C and C++ build gets one name in two spellings and a link that fails on
+ * a configuration that matches.
+ *
  * Frama-C analyses one translation unit at a time, so it has no mismatch to
  * catch, and the suffixed names would invalidate the '-wp-fct' list in the
- * Makefile. Leave its view of the names alone.
+ * Makefile, which still names 'tlsf_pool_reset'. WP skips a name it cannot
+ * resolve and the proved-goals count still balances, so that failure is silent.
+ * Leave its view of the names alone.
  */
 #ifndef __FRAMAC__
-#define _TLSF_ABI_PASTE(a, b) a##b
-#define _TLSF_ABI_EVAL(a, b) _TLSF_ABI_PASTE(a, b)
-#define _TLSF_ABI(name)                                        \
-    _TLSF_ABI_EVAL(_TLSF_ABI_EVAL(name##_w, _TLSF_SIZE_WIDTH), \
-                   _TLSF_ABI_EVAL(_fl, _TLSF_FL_MAX))
+#define _TLSF_ABI_PASTE(name, wid, flm) name##_w##wid##_fl##flm
+#define _TLSF_ABI_EVAL(name, wid, flm) _TLSF_ABI_PASTE(name, wid, flm)
+#define _TLSF_ABI(name) _TLSF_ABI_EVAL(name, _TLSF_SIZE_WIDTH, _TLSF_FL_MAX)
 
 #define tlsf_resize _TLSF_ABI(tlsf_resize)
 #define tlsf_aalloc _TLSF_ABI(tlsf_aalloc)

--- a/include/tlsf_thread.h
+++ b/include/tlsf_thread.h
@@ -36,10 +36,6 @@
 
 #pragma once
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "tlsf.h"
 
 #include <stddef.h>
@@ -70,21 +66,71 @@ extern "C" {
  */
 
 #ifndef TLSF_LOCK_T
-/* It is possible to switch to C11 threads. For this define TLSF_C11_THREADS
- * macro in this header here
+/* Define TLSF_C11_THREADS to select the C11 '<threads.h>' backend. It reaches
+ * the public symbol names, so it belongs in the build system and has to be seen
+ * by every translation unit or by none, exactly as tlsf.h asks of its own
+ * knobs.
+ *
+ * The arms below answer one question, "is there a '<threads.h>' to use", by
+ * whatever means the dialect offers, and they have to answer it alike or the
+ * two languages end up on different layouts.
+ *
+ * __STDC_NO_THREADS__ is therefore tested once, ahead of the split, and not
+ * inside any arm. The name says C, the practice does not: clang defines it in
+ * C++ mode, and defines it for its MSVC targets in both languages. An arm that
+ * skipped it would answer differently from an arm that did not, which is how
+ * clang-cl came to pick C11 threads from C and the native lock from C++ off the
+ * same flag.
+ *
+ * After that, C++ has no __STDC_VERSION__ to read and no compiler switch to
+ * demand, so the header's own presence is the evidence. __has_include is tested
+ * for before it is used, and the toolset version answers where it is missing.
+ * That fallback should never fire: GCC and clang offer the probe in every mode,
+ * and MSVC has offered it since VS 2017 15.3, well below the version this arm
+ * would then have to accept. It stays because the cost is two lines and the
+ * failure it covers is the one this change exists to remove, a C++ unit quietly
+ * on the native lock beside a C unit on 'mtx_t' off one flag. C11 threads ship
+ * in the VC runtime, not the Windows SDK, and arrived in VS 2022 17.8 together
+ * with 'vcruntime140_threads.dll'; that is where 1938 comes from. C reaches the
+ * same number through its own arm, which can also say what is wrong, an error
+ * no C++ build could have acted on.
+ *
+ * The generic C arm probes as well, for the mirror-image case: a C11 compiler
+ * that promises threads through __STDC_VERSION__ against a libc that ships no
+ * header. Taking its word there would fail on the include below while the C++
+ * unit beside it quietly took the native lock. Where the probe is missing the
+ * promise is all there is, which is where this arm started.
+ *
+ * That leaves g++ against a C library that sets __STDC_NO_THREADS__ while still
+ * shipping the header, where C declines and C++ accepts. The flag is opt-in,
+ * and the ABI suffix turns the disagreement into a link error rather than a
+ * corrupt 'tlsf_thread_t'.
  */
-#if defined(_MSC_VER) && defined(TLSF_C11_THREADS)
-#if (_MSC_VER < 1935)
-#error Incompatible Visual C++ version. Requires VS 2022 17.5+ for C11 threads support.
+#if defined(TLSF_C11_THREADS) && !defined(__STDC_NO_THREADS__)
+#if defined(__cplusplus)
+#if defined(__has_include)
+#if __has_include(<threads.h>)
+#define _TLSF_USE_C11_THREADS 1
+#endif
+#elif defined(_MSC_VER) && (_MSC_VER >= 1938)
+#define _TLSF_USE_C11_THREADS 1
+#endif
+#elif defined(_MSC_VER)
+#if (_MSC_VER < 1938)
+#error Incompatible Visual C++ version. Requires VS 2022 17.8+ for C11 threads support.
 #elif !defined(__STDC_VERSION__) || (__STDC_VERSION__ < 201112L)
 #error MSVC /std:c11 compiler switch is missing! Please enable C11 standard or higher in project properties.
 #else
-#define C11_THREADS_SUPPORT 1
+#define _TLSF_USE_C11_THREADS 1
+#endif
+#elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)
+#if defined(__has_include)
+#if __has_include(<threads.h>)
+#define _TLSF_USE_C11_THREADS 1
 #endif
 #else
-#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L) && \
-    !defined(__STDC_NO_THREADS__)
-#define C11_THREADS_SUPPORT 1
+#define _TLSF_USE_C11_THREADS 1
+#endif
 #endif
 #endif
 
@@ -95,12 +141,7 @@ extern "C" {
 #define TLSF_THREAD_POSIX
 #endif
 
-#if (defined(TLSF_THREAD_WIN) && defined(C11_THREADS_SUPPORT)) || \
-    (defined(TLSF_C11_THREADS) && defined(C11_THREADS_SUPPORT))
-#define USE_C11_THREADS 1
-#endif
-
-#if defined(USE_C11_THREADS)
+#if defined(_TLSF_USE_C11_THREADS)
 #include <threads.h>
 #elif defined(TLSF_THREAD_POSIX)
 #include <pthread.h>
@@ -123,7 +164,7 @@ extern "C" {
 #endif
 #endif
 
-#if defined(USE_C11_THREADS)
+#if defined(_TLSF_USE_C11_THREADS)
 #define TLSF_LOCK_T mtx_t
 /* C11 does not require thrd_success to be 0, so normalize it. */
 #define TLSF_LOCK_INIT(l) (mtx_init((l), mtx_plain) == thrd_success ? 0 : -1)
@@ -157,7 +198,7 @@ extern "C" {
 
 /* Fold upper bits into lower 32 to retain entropy on 64-bit systems. */
 #ifndef TLSF_THREAD_HINT
-#if defined(USE_C11_THREADS)
+#if defined(_TLSF_USE_C11_THREADS)
 #if defined(TLSF_THREAD_WIN)
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
@@ -231,41 +272,72 @@ TLSF_STATIC_ASSERT(TLSF_ARENA_COUNT >= 1, "TLSF_ARENA_COUNT must be >= 1");
 TLSF_STATIC_ASSERT((TLSF_CACHELINE_SIZE & (TLSF_CACHELINE_SIZE - 1)) == 0,
                    "TLSF_CACHELINE_SIZE must be a power of two");
 
-/* Which lock backend was selected, not which macro the caller passed. The
- * layout follows 'USE_C11_THREADS', and that is set either by TLSF_C11_THREADS
- * or on Windows whenever the compiler supports C11 threads, so keying this off
- * TLSF_C11_THREADS would both miss a real difference and invent one where the
- * flag changes nothing. A caller-supplied TLSF_LOCK_T skips the whole
- * selection, leaving this zero, which is why that case stays a caller
- * obligation.
+/* Which lock backend was selected, not which macro the caller passed. Every arm
+ * of the selection above lands on a different lock type, and two units that
+ * disagree about which one then disagree about 'base' and 'capacity', which sit
+ * behind the lock inside 'tlsf_arena_t'. Do not look for the damage in the
+ * arena stride. The cache-line padding absorbs a lock-size change until it
+ * crosses a whole line, so 'SRWLOCK' at one pointer and 'CRITICAL_SECTION' at
+ * 40 bytes give a byte-identical 'sizeof(tlsf_thread_t)'. Equal sizes are the
+ * ordinary case, not the exception, which is why the choice is encoded whole
+ * rather than measured or reduced to a C11-or-not flag.
+ *
+ * A boolean would miss the pair that needs it most. Nothing in the build system
+ * picks between 'SRWLOCK' and 'CRITICAL_SECTION': the header decides from
+ * '_WIN32_WINNT' and the compiler version, which a caller can set per
+ * translation unit, and a mismatched pair would then link cleanly, write the
+ * two fields at different offsets, and pass storage prepared by
+ * 'InitializeSRWLock' to 'EnterCriticalSection'.
+ *
+ * Keying off TLSF_C11_THREADS instead would both miss a real difference and
+ * invent one where the flag changes nothing, since the same flag reaches
+ * translation units whose toolchain has no '<threads.h>' to select. A
+ * caller-supplied TLSF_LOCK_T skips the whole selection, leaving this zero,
+ * which is why that case stays a caller obligation.
  */
-#if defined(USE_C11_THREADS)
-#define _TLSF_THREAD_C11_THREADS 1
+#if defined(_TLSF_USE_C11_THREADS)
+#define _TLSF_THREAD_BACKEND 1
+#elif defined(TLSF_THREAD_WIN_SRWLOCK)
+#define _TLSF_THREAD_BACKEND 2
+#elif defined(TLSF_THREAD_WIN_CRSECTION)
+#define _TLSF_THREAD_BACKEND 3
+#elif defined(TLSF_THREAD_POSIX)
+#define _TLSF_THREAD_BACKEND 4
 #else
-#define _TLSF_THREAD_C11_THREADS 0
+#define _TLSF_THREAD_BACKEND 0
 #endif
 
 /* Same hazard as the core allocator, and the same remedy: 'tlsf_thread_t' is
  * caller-allocated and its layout moves with TLSF_ARENA_COUNT,
  * TLSF_CACHELINE_SIZE and the embedded 'tlsf_t', so a translation unit that
  * disagrees about any of them corrupts the caller's object on the first call.
- * The core ABI suffix plus the thread-specific knobs, including the C11-threads
- * configuration, turn that into a link error. See the matching block in tlsf.h.
+ * The core ABI suffix plus the thread-specific knobs, including the selected
+ * lock backend, turn that into a link error. See the matching block in tlsf.h.
  *
  * A custom TLSF_LOCK_T also moves the layout and cannot be encoded in a token,
  * so it stays a caller obligation: define it in one place every translation
  * unit sees, the way the lock macros already have to be.
  *
- * _TLSF_ABI_EVAL comes from tlsf.h, included above, under the same __FRAMAC__
- * condition. Keep the two guards identical: relaxing one alone leaves this
- * block referring to a macro that no longer exists.
+ * One flat '##' chain fed by a single expansion layer, for the reason tlsf.h
+ * gives. The core half of the suffix is spelled again here rather than wrapped
+ * around _TLSF_ABI, because wrapping is the nesting that broke. Keep the two
+ * spellings in step; check-abi-guard.sh fails the thread target on a core knob
+ * if they drift. Parameters are not named for the separator letters they sit
+ * beside, or 'a##a' would paste the arena count to itself and drop the
+ * separator.
+ *
+ * Guarded on __FRAMAC__ like tlsf.h: relaxing one alone would suffix the
+ * wrapper's names while leaving the core's plain, or the reverse.
  */
 #ifndef __FRAMAC__
-#define _TLSF_THREAD_ABI(name)                                                \
-    _TLSF_ABI_EVAL(                                                           \
-        _TLSF_ABI_EVAL(_TLSF_ABI(name), _TLSF_ABI_EVAL(a, TLSF_ARENA_COUNT)), \
-        _TLSF_ABI_EVAL(_TLSF_ABI_EVAL(c, TLSF_CACHELINE_SIZE),                \
-                       _TLSF_ABI_EVAL(t, _TLSF_THREAD_C11_THREADS)))
+#define _TLSF_THREAD_ABI_PASTE(name, wid, flm, arena, cache, bk) \
+    name##_w##wid##_fl##flm##a##arena##c##cache##t##bk
+#define _TLSF_THREAD_ABI_EVAL(name, wid, flm, arena, cache, bk) \
+    _TLSF_THREAD_ABI_PASTE(name, wid, flm, arena, cache, bk)
+#define _TLSF_THREAD_ABI(name)                                   \
+    _TLSF_THREAD_ABI_EVAL(name, _TLSF_SIZE_WIDTH, _TLSF_FL_MAX,  \
+                          TLSF_ARENA_COUNT, TLSF_CACHELINE_SIZE, \
+                          _TLSF_THREAD_BACKEND)
 
 #define tlsf_thread_init _TLSF_THREAD_ABI(tlsf_thread_init)
 #define tlsf_thread_destroy _TLSF_THREAD_ABI(tlsf_thread_destroy)
@@ -276,6 +348,17 @@ TLSF_STATIC_ASSERT((TLSF_CACHELINE_SIZE & (TLSF_CACHELINE_SIZE - 1)) == 0,
 #define tlsf_thread_check _TLSF_THREAD_ABI(tlsf_thread_check)
 #define tlsf_thread_stats _TLSF_THREAD_ABI(tlsf_thread_stats)
 #define tlsf_thread_reset _TLSF_THREAD_ABI(tlsf_thread_reset)
+#endif
+
+/* Everything above is includes, macros and static assertions, none of which
+ * needs C linkage, and one of the includes is '<threads.h>' or '<windows.h>'.
+ * Opening the block here rather than at the top of the file keeps those system
+ * headers out of it. A C++ unit only started reaching '<threads.h>' when the
+ * selection above grew its C++ arm, so this is the one placement that does not
+ * rest on a system header tolerating a language linkage it never asked for.
+ */
+#ifdef __cplusplus
+extern "C" {
 #endif
 
 TLSF_MSVC_ALIGN(TLSF_CACHELINE_SIZE) typedef struct {

--- a/tests/test_thread.c
+++ b/tests/test_thread.c
@@ -43,7 +43,7 @@
 TLSF_MSVC_ALIGN(16) static char pool[POOL_SIZE] TLSF_GCC_ALIGN(16);
 static tlsf_thread_t ts;
 
-#if defined(USE_C11_THREADS)
+#if defined(_TLSF_USE_C11_THREADS)
 #define TLSF_THREAD_T thrd_t
 #define TLSF_CREATE_THREAD(thrd, func, arg) thrd_create(thrd, func, arg)
 #define TLSF_JOIN_THREAD(thrd) thrd_join((thrd), NULL)


### PR DESCRIPTION
A C++ translation unit could not link against the C library on MSVC. Issue #40 reports it as an unresolved external symbol naming "tlsf_thread_destroy_w64_fl39a4c64t0". There are two independent causes, and the link needs both of them gone.

The first is the lock backend. USE_C11_THREADS was set on Windows whenever the compiler had C11 threads, with no opt-in, so a /std:c11 unit selected "mtx_t" while the C++ unit beside it had no <threads.h> to select and took the native lock. Two layouts for one "tlsf_thread_t", which is what the ABI suffix exists to catch. Requiring TLSF_C11_THREADS keeps both languages on the native lock by default. MSVC also rejected that macro in C++ mode with an error telling the user to enable /std:c11, advice no C++ build can follow; that branch now falls through the way MinGW and clang already did.

The second is the token paste. Feeding one paste the result of another is spelled differently by MSVC's two preprocessors, and a mixed build spans both: /std:c11 turns on /Zc:preprocessor by itself while the C++ modes leave it opt-in. Splicing every knob into one flat "##" chain under a single expansion layer removes the difference. The reporter saw this only in tlsf_thread.h, where the nesting ran four deep. tlsf.h is flattened alongside it as a precaution, not as a reported fix, since it uses the same idiom and the change costs nothing.

Measured on the emitted symbols, which do not move: tlsf_malloc stays "tlsf_malloc_w64_fl39" and tlsf_thread_init stays
"tlsf_thread_init_w64_fl39a4c64t0". The suffix still tracks every knob, giving a7c128 for TLSF_ARENA_COUNT=7 with TLSF_CACHELINE_SIZE =128, fl20 for TLSF_MAX_POOL_BITS=20, and w32 for a 32-bit size width. An expression-valued knob still fails to compile at the same declaration as before. Against a stub <threads.h> the two languages diverge as described, t1 against t0, and the link fails on the undefined t0 symbols; against the pre-change header, C++ with TLSF_C11_THREADS stops at the /std:c11 error, and after it resolves to t0.

The MSVC C++ compile and run steps are the regression check. Neither passes TLSF_C11_THREADS, so reverting either half fails the link. The wrapper gets its own step because a step reports the exit status of its last command only, which would let a failed compile through and link a stale object.

make check passes with and without TLSF_DEBUG_FLAGS. check-abi-guard, check-format, check-newline and cppcheck under the CI flags are clean, and line coverage of src/tlsf.c is 99.37 percent against a 99 percent floor.

Close #40

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the MSVC link failure between C and C++ translation units by making both languages agree on the thread wrapper ABI. Windows builds now default to the native lock instead of selecting C11 `mtx_t` whenever the compiler had C11 threads, the nested token paste that MSVC's two preprocessors spell differently is flattened into a single chain, and the ABI suffix now encodes the exact lock backend.

- `TLSF_C11_THREADS` opts into C11 threads from either language, with the C++ arm probing via `__has_include`; `C11_THREADS_SUPPORT` is removed, and on toolchains where the languages disagree about the header the flag should stay off.
- MSVC C11 threads now require VS 2022 17.8 or newer, up from 17.5.
- Windows builds that used to reach `mtx_t` without the flag now get the native lock; a full rebuild is needed, and a partial one fails at link time.
- The backend tag now distinguishes `SRWLOCK` from `CRITICAL_SECTION`, so a per-unit `_WIN32_WINNT` mix can no longer link and then corrupt `tlsf_thread_t`.
- The ABI guard now fails the thread target on a core knob and verifies the two Windows lock backends emit distinct symbol names; CI runs MSVC C++ compile/run checks with and without the flag plus a glibc C11 matrix entry.

Fixes #40.

<sup>Written for commit c9336cad9d12702c98edd6763c217127f8bb0ea0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/tlsf-bsd/pull/41?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

