### PR TITLE
`largest_free` reports the size of the largest allocation that can actually succeed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,15 +36,10 @@ jobs:
       # analyser comments in the allocator. cppcheck cannot evaluate sizeof on
       # a struct it has only seen declared, so it folds BLOCK_SIZE_MIN to zero
       # and reports adjust_size() as comparing an unsigned value against zero.
-      # Pinned to its line, like the others below, so the id still fires
-      # anywhere else in the allocator.
       # And it has no model for weak linkage, so it treats the default
       # tlsf_resize() as the only definition and calls every success branch
-      # that depends on an override unreachable. Those three are pinned to
-      # their lines rather than to the file, so a real always-true condition
-      # elsewhere in the allocator still fails the job. A line that moves
-      # makes its suppression stop matching and the job fail, which is the
-      # loud direction to fail in.
+      # that depends on an override unreachable. That is one limitation, not
+      # the three findings it reports.
       #
       # The third is the preprocessor emulation giving up on the ABI guard.
       # Older simplecpp, including the one in the cppcheck Ubuntu 24.04 ships,
@@ -56,14 +51,17 @@ jobs:
       # The suppressions are flags rather than a suppression file: the file
       # format is not portable across cppcheck versions, and the one in Ubuntu
       # 24.04 rejects the comments that made the file worth having.
+      #
+      # They are scoped to a file, not a line. Line-pinned suppressions move
+      # under any edit above them and only this job notices. The cost is that
+      # a genuine always-true condition in src/tlsf.c no longer fails the job;
+      # every other id, and every other file, still does.
       - name: Static analysis
         run: |
           cppcheck --enable=warning,style,performance,portability --std=c11 \
             -I include --suppress=missingIncludeSystem \
-            --suppress=unsignedLessThanZero:src/tlsf.c:750 \
-            --suppress=knownConditionTrueFalse:src/tlsf.c:1286 \
-            --suppress=knownConditionTrueFalse:src/tlsf.c:1387 \
-            --suppress=knownConditionTrueFalse:src/tlsf.c:1477 \
+            --suppress=unsignedLessThanZero:src/tlsf.c \
+            --suppress=knownConditionTrueFalse:src/tlsf.c \
             --suppress=preprocessorErrorDirective:include/tlsf.h \
             --suppress=preprocessorErrorDirective:include/tlsf_thread.h \
             --error-exitcode=1 --quiet src include

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 *.swp
 *.fuse*
 *.pyc
+*.gcov
 *.swo
 *.out
 build/

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,8 @@ TARGETS = \
 	test \
 	bench \
 	wcet \
-	fuzz
+	fuzz \
+	check_negative
 TARGETS := $(addprefix $(OUT)/,$(TARGETS))
 
 THREAD_TARGETS = $(OUT)/test_thread
@@ -91,7 +92,7 @@ THREAD_OBJS = $(OUT)/tlsf_thread.o
 # Every rule that passes -MMD -MF must be listed, or 'clean' leaves its dep
 # file behind. $(OUT)/test is deliberately absent: its rule emits no dep file.
 deps := $(OBJS:%.o=%.o.d) $(THREAD_OBJS:%.o=%.o.d) \
-	$(OUT)/bench.d $(OUT)/wcet.d $(OUT)/fuzz.d \
+	$(OUT)/bench.d $(OUT)/wcet.d $(OUT)/fuzz.d $(OUT)/check_negative.d \
 	$(THREAD_TARGETS:%=%.d) $(CPP_TARGETS:%=%.d)
 
 # Make compares timestamps, not command lines, so flipping a variable on the
@@ -140,6 +141,11 @@ $(OUT)/fuzz: $(OBJS) tests/fuzz.c $(FLAGS_STAMP)
 	$(CC) $(CPPFLAGS) $(CFLAGS) -Itests -o $@ -MMD -MF $@.d $(OBJS) \
 		tests/fuzz.c $(LDFLAGS)
 
+# Deliberate heap corruption, one case per process. See the file header.
+$(OUT)/check_negative: $(OBJS) tests/check_negative.c $(FLAGS_STAMP)
+	$(CC) $(CPPFLAGS) $(CFLAGS) -Itests -o $@ -MMD -MF $@.d $(OBJS) \
+		tests/check_negative.c $(LDFLAGS)
+
 # Thread-safe module (requires pthreads)
 $(OUT)/tlsf_thread.o: src/tlsf_thread.c include/tlsf_thread.h $(FLAGS_STAMP)
 	@mkdir -p $(OUT)
@@ -158,7 +164,7 @@ $(OUT)/%.o: src/%.c $(FLAGS_STAMP)
 	@mkdir -p $(OUT)
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c -o $@ -MMD -MF $@.d $<
 
-check: $(TARGETS) $(THREAD_TARGETS) $(CPP_TARGETS)
+check: $(TARGETS) $(THREAD_TARGETS) $(CPP_TARGETS) check-negative
 	MALLOC_CHECK_=3 ./build/test
 	MALLOC_CHECK_=3 ./build/bench -l 10000 -i 3 -w 1
 	MALLOC_CHECK_=3 ./build/bench -s 32 -l 10000 -i 3 -w 1
@@ -167,6 +173,39 @@ check: $(TARGETS) $(THREAD_TARGETS) $(CPP_TARGETS)
 	MALLOC_CHECK_=3 ./build/fuzz
 	./build/test_thread
 	./build/test_cpp
+
+# Each case must abort with a CHECK diagnostic, not a segfault that looks like
+# one. Two ways this fails open, both closed here: a fixture broken in seed()
+# would abort every case alike, so the control run goes first; a build without
+# TLSF_ENABLE_CHECK has no rejection to observe, so the driver reports zero
+# cases and this skips. The count arrives as an exit status, so a driver that
+# dies at startup yields a number past the last case, which the driver itself
+# then rejects. Cores are off because the aborts are expected.
+check-negative: $(OUT)/check_negative
+	@ulimit -c 0; \
+	./$(OUT)/check_negative; n=$$?; \
+	if [ "$$n" -eq 0 ]; then \
+		echo "check_negative: skipped (built without TLSF_ENABLE_CHECK)"; \
+		exit 0; \
+	fi; \
+	if ! ./$(OUT)/check_negative -1 >/dev/null 2>&1; then \
+		echo "check_negative: control case failed; harness is broken" >&2; \
+		exit 1; \
+	fi; \
+	i=0; \
+	while [ "$$i" -lt "$$n" ]; do \
+		if out=$$(./$(OUT)/check_negative $$i 2>&1); then \
+			echo "check_negative: case $$i accepted by tlsf_check()" >&2; \
+			exit 1; \
+		fi; \
+		case "$$out" in \
+		*"TLSF CHECK:"*) ;; \
+		*) echo "check_negative: case $$i failed with no CHECK diagnostic:" \
+			>&2; echo "$$out" >&2; exit 1 ;; \
+		esac; \
+		i=$$((i + 1)); \
+	done; \
+	echo "check_negative: $$n corruptions, each rejected by tlsf_check()"
 
 # RTE guards are emitted as ACSL asserts, so filtering out @assert would discard
 # every runtime-error obligation that -wp-rte just generated. Keep them counted.
@@ -235,7 +274,7 @@ clean:
 	$(RM) $(OUT)/*.gcda $(OUT)/*.gcno *.gcov
 	$(RM) -r $(OUT)/*.dSYM
 
-.PHONY: all check clean verify bench bench-quick fuzz wcet wcet-quick \
-	wcet-plot FORCE
+.PHONY: all check check-negative clean verify bench bench-quick fuzz wcet \
+	wcet-quick wcet-plot FORCE
 
 -include $(deps)

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,9 @@ WP_FUNCTIONS = \
 	block_set_prev_free,block_set_free_at,free_list_link, \
 	free_list_unlink,bin_set_head, \
 	bins_reset,adjust_size,block_prev,block_poison_free,check_sentinel, \
-	bitmap_ffs,log2floor,block_next,round_block_size,align_offset,mapping, \
+	bitmap_ffs,log2floor,block_next,round_block_size,floor_block_size, \
+	block_size_mask, \
+	align_offset,mapping, \
 	tlsf_pool_reset,remove_free_block,insert_free_block
 
 TARGETS = \

--- a/include/tlsf.h
+++ b/include/tlsf.h
@@ -390,6 +390,15 @@ void tlsf_pool_reset(tlsf_t *t);
  *
  * Return Pointer to at least @size bytes, aligned to ALIGN_SIZE (8 on 64-bit, 4
  * on 32-bit), or NULL on failure.
+ *
+ * ALIGN_SIZE is pinned to sizeof(size_t): the one-word header makes
+ * BLOCK_OVERHEAD sizeof(size_t), and both it and BLOCK_SIZE_MIN must be
+ * multiples of the alignment. Raising it costs a wider header on every
+ * allocation.
+ *
+ * On 32-bit the resulting 4 bytes is under _Alignof(max_align_t), 16 on i386,
+ * so this is not a conforming malloc() substitute there for over-aligned
+ * types. Use tlsf_aalloc(), which takes the alignment explicitly.
  */
 /*@
   requires \valid(t);

--- a/include/tlsf.h
+++ b/include/tlsf.h
@@ -482,7 +482,7 @@ static inline void tlsf_check(tlsf_t *t)
  */
 typedef struct {
     size_t total_free;   /* Total free bytes available */
-    size_t largest_free; /* Largest contiguous free block */
+    size_t largest_free; /* Largest contiguous allocation that can succeed */
     size_t total_used;   /* Total bytes in allocated blocks */
     size_t block_count;  /* Total number of blocks (free + used) */
     size_t free_count;   /* Number of free blocks (fragmentation indicator) */

--- a/include/tlsf_thread.h
+++ b/include/tlsf_thread.h
@@ -461,8 +461,8 @@ void tlsf_thread_check(tlsf_thread_t *ts);
 
 /**
  * Aggregate statistics across all arenas. largest_free reports the single
- * largest free block in any one arena, which is the largest allocation that can
- * still succeed, not the sum of free space.
+ * largest allocation that can succeed in any one arena, not the sum of free
+ * space.
  *
  * Not an atomic snapshot: arena locks are taken one at a time, so concurrent
  * allocations in an already-visited arena are not reflected. Quiesce the other

--- a/src/tlsf.c
+++ b/src/tlsf.c
@@ -754,10 +754,24 @@ INLINE size_t adjust_size(size_t size, size_t align)
  * BLOCK_SIZE_SMALL), the rounding mask is zero, producing an identity. For
  * large sizes, it rounds up to the next second-level bin boundary.
  */
-/* Round up to the next block size. Branch-free: for small sizes (<
- * BLOCK_SIZE_SMALL), the rounding mask is zero, producing an identity. For
- * large sizes, it rounds up to the next second-level bin boundary.
+/* Second-level bin mask: all-zero below BLOCK_SIZE_SMALL, where bins are
+ * linear, and (1 << shift) - 1 above it. Both rounding directions need it, so
+ * it lives here rather than twice.
+ *
+ * The shift clamp is load-bearing, not defensive: an aligned size still only
+ * gives lg >= ALIGN_SHIFT, so lg - SL_SHIFT wraps for the smallest sizes and
+ * would be undefined without it. The wrapped value is harmless because
+ * is_large is zero there and zero shifted by anything is zero.
  */
+INLINE size_t block_size_mask(size_t size)
+{
+    uint32_t lg = log2floor(size);
+    size_t is_large = (size_t) (lg >= (uint32_t) FL_SHIFT);
+    uint32_t shift =
+        (lg - (uint32_t) SL_SHIFT) & ((uint32_t) (_TLSF_SIZE_WIDTH - 1));
+    return (is_large << shift) - is_large;
+}
+
 /*@
   requires size > 0;
   requires size <= TLSF_MAX_SIZE;
@@ -766,17 +780,7 @@ INLINE size_t adjust_size(size_t size, size_t align)
 */
 INLINE size_t round_block_size(size_t size)
 {
-    uint32_t lg = log2floor(size);
-    size_t is_large = (size_t) (lg >= (uint32_t) FL_SHIFT);
-
-    /* Clamp shift to valid range; garbage value is harmless when is_large=0
-     * because shifting zero by any valid amount yields zero.
-     */
-    uint32_t shift =
-        (lg - (uint32_t) SL_SHIFT) & ((uint32_t) (_TLSF_SIZE_WIDTH - 1));
-    size_t round = is_large << shift;
-    /* Large: (1 << shift) - 1 = SL rounding mask.  Small: 0 - 0 = 0. */
-    size_t t = round - is_large;
+    size_t t = block_size_mask(size);
     return (size + t) & ~t;
 }
 
@@ -788,12 +792,7 @@ INLINE size_t round_block_size(size_t size)
  */
 INLINE size_t floor_block_size(size_t size)
 {
-    uint32_t lg = log2floor(size);
-    size_t is_large = (size_t) (lg >= (uint32_t) FL_SHIFT);
-    uint32_t shift =
-        (lg - (uint32_t) SL_SHIFT) & ((uint32_t) (_TLSF_SIZE_WIDTH - 1));
-    size_t round = is_large << shift;
-    return size & ~(round - is_large);
+    return size & ~block_size_mask(size);
 }
 
 /* Map size to first-level (fl) and second-level (sl) bin indices. Branch-free:

--- a/src/tlsf.c
+++ b/src/tlsf.c
@@ -609,8 +609,13 @@ INLINE tlsf_block_t *block_next(tlsf_block_t *block)
     return next;
 }
 
+/* Only 'prev' is written, so only 'prev' need be addressable. Requiring the
+ * whole block would oblige every caller to establish more than this needs,
+ * which is what blocks block_link_next(): block_next()'s span predicate stops
+ * one header short of a full tlsf_block_t.
+ */
 /*@
-  requires \valid(next);
+  requires \valid(&next->prev);
   assigns next->prev \from block;
   ensures next->prev == block;
 */

--- a/src/tlsf.c
+++ b/src/tlsf.c
@@ -754,6 +754,10 @@ INLINE size_t adjust_size(size_t size, size_t align)
  * BLOCK_SIZE_SMALL), the rounding mask is zero, producing an identity. For
  * large sizes, it rounds up to the next second-level bin boundary.
  */
+/* Round up to the next block size. Branch-free: for small sizes (<
+ * BLOCK_SIZE_SMALL), the rounding mask is zero, producing an identity. For
+ * large sizes, it rounds up to the next second-level bin boundary.
+ */
 /*@
   requires size > 0;
   requires size <= TLSF_MAX_SIZE;
@@ -774,6 +778,22 @@ INLINE size_t round_block_size(size_t size)
     /* Large: (1 << shift) - 1 = SL rounding mask.  Small: 0 - 0 = 0. */
     size_t t = round - is_large;
     return (size + t) & ~t;
+}
+
+/* The inverse direction: the largest request this block size can serve, since
+ * a request is rounded up and must still fit. Takes any mappable block size,
+ * including one above TLSF_MAX_SIZE, which coalescing and pool appends do
+ * build; capping belongs to the caller and cannot be done first without
+ * under-reporting.
+ */
+INLINE size_t floor_block_size(size_t size)
+{
+    uint32_t lg = log2floor(size);
+    size_t is_large = (size_t) (lg >= (uint32_t) FL_SHIFT);
+    uint32_t shift =
+        (lg - (uint32_t) SL_SHIFT) & ((uint32_t) (_TLSF_SIZE_WIDTH - 1));
+    size_t round = is_large << shift;
+    return size & ~(round - is_large);
 }
 
 /* Map size to first-level (fl) and second-level (sl) bin indices. Branch-free:
@@ -1940,6 +1960,7 @@ void tlsf_check(tlsf_t *t)
  * - overhead: Metadata bytes (block headers + sentinel)
  * - block_count: Total blocks including used and free
  * - free_count: Number of free blocks (fragmentation indicator)
+ * - largest_free: Largest single allocation the allocator can serve
  */
 int tlsf_get_stats(tlsf_t *t, tlsf_stats_t *stats)
 {
@@ -1972,10 +1993,17 @@ int tlsf_get_stats(tlsf_t *t, tlsf_stats_t *stats)
         stats->overhead += BLOCK_OVERHEAD;
 
         if (block_is_free(block)) {
+            /* Floor first, then cap. Capping first would floor the cap and
+             * report less than tlsf_malloc() will actually serve.
+             */
+            size_t floored = floor_block_size(bsize);
+            size_t alloc_size =
+                floored > TLSF_MAX_SIZE ? TLSF_MAX_SIZE : floored;
+
             stats->free_count++;
             stats->total_free += bsize;
-            if (bsize > stats->largest_free)
-                stats->largest_free = bsize;
+            if (alloc_size > stats->largest_free)
+                stats->largest_free = alloc_size;
         } else {
             stats->total_used += bsize;
         }

--- a/src/tlsf.c
+++ b/src/tlsf.c
@@ -763,6 +763,11 @@ INLINE size_t adjust_size(size_t size, size_t align)
  * would be undefined without it. The wrapped value is harmless because
  * is_large is zero there and zero shifted by anything is zero.
  */
+/*@
+  requires size > 0;
+  requires size < ((size_t) 1 << FL_MAX);
+  assigns \nothing;
+*/
 INLINE size_t block_size_mask(size_t size)
 {
     uint32_t lg = log2floor(size);
@@ -789,7 +794,17 @@ INLINE size_t round_block_size(size_t size)
  * including one above TLSF_MAX_SIZE, which coalescing and pool appends do
  * build; capping belongs to the caller and cannot be done first without
  * under-reporting.
+ *
+ * No postcondition, so WP proves only the absence of runtime errors here.
+ * Alt-Ergo timed out at 240s on each of '\result <= size', '\result > 0' and
+ * '\result % ALIGN_SIZE == 0'; bit reasoning over a computed shift is beyond
+ * it. round_block_size() is unannotated for the same reason.
  */
+/*@
+  requires size > 0;
+  requires size < ((size_t) 1 << FL_MAX);
+  assigns \nothing;
+*/
 INLINE size_t floor_block_size(size_t size)
 {
     return size & ~block_size_mask(size);

--- a/src/tlsf.c
+++ b/src/tlsf.c
@@ -536,7 +536,12 @@ INLINE char *block_payload(tlsf_block_t *block)
 INLINE tlsf_block_t *to_block(void *ptr)
 {
     tlsf_block_t *block = (tlsf_block_t *) ptr;
-    ASSERT(block_payload(block) == align_ptr(block_payload(block), ALIGN_SIZE),
+    /* align_offset(), not align_ptr(): this only tests alignment, and
+     * align_ptr() would additionally require the caller to own a full
+     * alignment window that to_block() cannot promise. The two are
+     * equivalent here, since align_ptr(p, a) is p + align_offset(p, a).
+     */
+    ASSERT(align_offset(block_payload(block), ALIGN_SIZE) == 0,
            "block not aligned properly");
     return block;
 }

--- a/tests/check_negative.c
+++ b/tests/check_negative.c
@@ -1,0 +1,166 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * tlsf-bsd is freely redistributable under the BSD License. See the file
+ * "LICENSE" for information on usage and redistribution of this file.
+ */
+
+/* Negative-path coverage for tlsf_check().
+ *
+ * Every other call of it in the suite expects it to pass, which proves only
+ * that it accepts valid states: gutting the body to '(void) t;' left both
+ * tests/test.c and tests/test_thread.c green. One case per walk function, so
+ * dropping any of the three fails here.
+ *
+ *   case 0  null allocator              tlsf_check() itself
+ *   case 1  arena size disagrees        check_block_chain()
+ *   case 2  bitmap bit claims an
+ *           empty bin                   check_free_lists()
+ *   case 3  free-list back link points
+ *           at the wrong block          check_bin_list()
+ *
+ * CHECK() aborts, so each case needs its own process; the Makefile runner
+ * drives them by index and asserts both the abort and the diagnostic. Case -1
+ * corrupts nothing and must exit cleanly, or a harness broken for its own
+ * reasons would look like success on every case.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "tlsf.h"
+
+#include "pool_limits.h"
+
+/* Without TLSF_ENABLE_CHECK there is no rejection to observe, so report no
+ * cases and let the runner skip rather than pass vacuously.
+ */
+#ifdef TLSF_ENABLE_CHECK
+#define CASE_COUNT 4
+#else
+#define CASE_COUNT 0
+#endif
+
+static char pool[TLSF_TEST_POOL_CLAMP(64 * 1024)];
+
+/* Occupy several bins, so the bitmap and free-list cases have targets. */
+static void seed(tlsf_t *t)
+{
+    void *live[8], *dead[8];
+
+    for (size_t i = 0; i < 8; i++) {
+        live[i] = tlsf_malloc(t, 32 + i * 64);
+        dead[i] = tlsf_malloc(t, 48 + i * 96);
+        if (!live[i] || !dead[i]) {
+            fprintf(stderr, "check_negative: seed allocation failed\n");
+            exit(2);
+        }
+    }
+
+    /* Allocated alternately, so freeing one array leaves holes the survivors
+     * keep from merging.
+     */
+    for (size_t i = 0; i < 8; i++)
+        tlsf_free(t, dead[i]);
+
+    tlsf_check(t); /* the fixture itself must be valid */
+}
+
+/* Lowest first-level index with a clear bit, else _TLSF_FL_COUNT. */
+static uint32_t first_clear_fl(const tlsf_t *t)
+{
+    uint32_t i = 0;
+    while (i < _TLSF_FL_COUNT && (t->fl & (1U << i)))
+        i++;
+    return i;
+}
+
+/* A block sitting on some free list, or NULL if the fixture left none. */
+static struct tlsf_block *any_free_block(tlsf_t *t)
+{
+    for (uint32_t i = 0; i < _TLSF_FL_COUNT; i++) {
+        for (uint32_t j = 0; j < _TLSF_SL_COUNT; j++) {
+            if (t->block[i][j] != &t->block_null)
+                return t->block[i][j];
+        }
+    }
+    return NULL;
+}
+
+int main(int argc, char **argv)
+{
+    /* No case index: report how many there are through the exit status, which
+     * the shell already guarantees is a small integer, so the runner needs no
+     * parsing and no validation of what it parsed.
+     */
+    if (argc != 2)
+        return CASE_COUNT;
+
+    char *end;
+    const long which = strtol(argv[1], &end, 10);
+    if (*end || end == argv[1]) {
+        fprintf(stderr, "check_negative: not a case number: %s\n", argv[1]);
+        return 2;
+    }
+
+    /* Needs no pool, so it runs before one exists. */
+    if (which == 0) {
+        tlsf_check(NULL);
+        fprintf(stderr, "check_negative: case 0 returned\n");
+        return 1;
+    }
+
+    tlsf_t t;
+    if (!tlsf_pool_init(&t, pool, sizeof(pool))) {
+        fprintf(stderr, "check_negative: pool init failed\n");
+        return 2;
+    }
+    seed(&t);
+
+    switch (which) {
+    case -1: /* control: seed() already checked the untouched fixture */
+        return 0;
+
+    case 1:
+        /* One alignment unit breaks the size reconciliation and leaves every
+         * pointer valid, so the walk reaches it.
+         */
+        t.size += sizeof(size_t);
+        break;
+
+    case 2: {
+        /* A first-level bit over an empty second-level bitmap. Bins untouched,
+         * so nothing new is dereferenced.
+         */
+        uint32_t fl = first_clear_fl(&t);
+        if (fl >= _TLSF_FL_COUNT) {
+            fprintf(stderr, "check_negative: no clear FL bit to set\n");
+            return 2;
+        }
+        t.fl |= 1U << fl;
+        break;
+    }
+
+    case 3: {
+        /* A list head must point back at the sentinel. Point it at itself: a
+         * valid address, wrong value.
+         */
+        struct tlsf_block *block = any_free_block(&t);
+        if (!block) {
+            fprintf(stderr, "check_negative: fixture left no free block\n");
+            return 2;
+        }
+        block->prev_free = block;
+        break;
+    }
+
+    default:
+        fprintf(stderr, "check_negative: no such case: %s\n", argv[1]);
+        return 2;
+    }
+
+    tlsf_check(&t);
+
+    /* Reached only when tlsf_check() accepted a state it must reject. */
+    fprintf(stderr, "check_negative: case %ld was not detected\n", which);
+    return 1;
+}

--- a/tests/fuzz.c
+++ b/tests/fuzz.c
@@ -15,10 +15,10 @@
  *
  * The payload of every live block carries a tag, verified before the block is
  * handed back. That catches the failure this allocator would otherwise hide,
- * two live allocations overlapping, which no heap invariant can see because
- * the metadata stays perfectly consistent. The tag is derived from the slot
- * index, so no two blocks that are live at the same moment can carry the same
- * one, which is the property the check rests on.
+ * two live allocations overlapping, which no heap invariant can see because the
+ * metadata stays perfectly consistent. The tag is derived from the slot index,
+ * so no two blocks that are live at the same moment can carry the same one,
+ * which is the property the check rests on.
  *
  * Two entry points, one body. Built with -fsanitize=fuzzer the file provides
  * LLVMFuzzerTestOneInput and libFuzzer drives it; built any other way it gets a
@@ -207,8 +207,8 @@ int main(void)
     uint32_t state = used;
 
     /* Before the rounds, not after. An assertion inside the target aborts the
-     * process, and a seed printed at the end is a seed printed only when it
-     * was not needed.
+     * process, and a seed printed at the end is a seed printed only when it was
+     * not needed.
      */
     printf("Fuzz target replay: seed 0x%08x (set TLSF_FUZZ_SEED), ", used);
     fflush(stdout);

--- a/tests/test.c
+++ b/tests/test.c
@@ -1270,6 +1270,91 @@ static void small_bin_trim_test(void)
            seeded, got);
 }
 
+/* block_can_trim()'s bound is inclusive: a block exactly large enough to leave
+ * BLOCK_OVERHEAD + TLSF_SPLIT_THRESHOLD behind must still split. Making it
+ * exclusive wastes a few bytes per allocation, which no throughput figure or
+ * consistency check notices, and the suite passed with it. The block here is
+ * that exact size, so an off-by-one either way changes the outcome.
+ */
+static void trim_boundary_test(void)
+{
+    printf("Trim boundary test: ");
+    fflush(stdout);
+
+    /* Both sizes must sit in the FL=0 linear range, where rounding is the
+     * identity; above it the block built is not the one reasoned about here.
+     */
+    const size_t fast_path_max = (size_t) 1 << _TLSF_FL_SHIFT;
+    const size_t remainder = sizeof(size_t) + TLSF_TEST_SPLIT_THRESHOLD;
+    const size_t req = fast_path_max / 4;
+    const size_t exact = req + remainder;
+    if (exact >= fast_path_max) {
+        printf(
+            "skipped (split threshold %zu leaves no room below the %zu-byte "
+            "FL=0 ceiling)\n",
+            (size_t) TLSF_TEST_SPLIT_THRESHOLD, fast_path_max);
+        return;
+    }
+
+    /* An unaligned split threshold is legal and the library is right under
+     * one: block sizes and adjusted requests are both alignment multiples, so
+     * their difference is too and never equals an unaligned min_total. The
+     * boundary is unreachable, not broken, so skip rather than fail.
+     */
+    if (remainder % sizeof(size_t)) {
+        printf(
+            "skipped (split threshold %zu is not alignment-sized, so the "
+            "boundary cannot be hit)\n",
+            (size_t) TLSF_TEST_SPLIT_THRESHOLD);
+        return;
+    }
+
+    static char pool[TLSF_TEST_POOL_CLAMP(64 * 1024)];
+    tlsf_t t;
+    assert(tlsf_pool_init(&t, pool, sizeof(pool)));
+
+    /* Live neighbours, so freeing the donor cannot coalesce it past the
+     * boundary being measured.
+     */
+    void *lo = tlsf_malloc(&t, 64);
+    void *donor = tlsf_malloc(&t, exact);
+    void *hi = tlsf_malloc(&t, 64);
+    assert(lo && donor && hi);
+    assert(tlsf_usable_size(donor) == exact); /* else rounding moved it */
+
+    void *addr = donor;
+    tlsf_free(&t, donor);
+    tlsf_check(&t);
+
+    tlsf_stats_t before;
+    assert(tlsf_get_stats(&t, &before) == 0);
+
+    /* The donor is the smallest free block, so the search lands on it and
+     * leaves exactly the threshold. That it lands there is a fixture
+     * assumption, asserted rather than trusted: without it the checks below
+     * would pass on a block from the pool tail and prove nothing.
+     */
+    void *p = tlsf_malloc(&t, req);
+    assert(p == addr);
+    assert(tlsf_usable_size(p) == req);
+
+    /* Trimmed: donor became one used block plus one free remainder, so the
+     * count holds. Handing out the whole block would drop it.
+     */
+    tlsf_stats_t after;
+    assert(tlsf_get_stats(&t, &after) == 0);
+    assert(after.free_count == before.free_count);
+
+    tlsf_check(&t);
+    tlsf_free(&t, p);
+    tlsf_free(&t, lo);
+    tlsf_free(&t, hi);
+    tlsf_check(&t);
+
+    printf("%zu-byte block split at a %zu-byte remainder, done\n", exact,
+           remainder);
+}
+
 /* Null arguments and requests past TLSF_MAX_SIZE.
  *
  * The null rejects and the TLSF_MAX_SIZE bound are reached by nothing else in
@@ -1717,6 +1802,7 @@ int main(void)
 
     /* Run small-bin trim test */
     small_bin_trim_test();
+    trim_boundary_test();
 
     /* Run pool ceiling test */
     pool_ceiling_test();

--- a/tests/test.c
+++ b/tests/test.c
@@ -1363,6 +1363,17 @@ static void pool_ceiling_test(void)
            align);
 }
 
+/* The claim the whole largest_free change rests on: the reported figure names
+ * a size malloc() will serve, not merely a block that exists.
+ */
+static void assert_largest_free_allocatable(tlsf_t *t, size_t largest)
+{
+    assert(largest <= TLSF_MAX_SIZE);
+    void *p = tlsf_malloc(t, largest);
+    assert(p);
+    tlsf_free(t, p);
+}
+
 /* A coalesced free block may exceed BLOCK_SIZE_MAX, which bounds a single
  * allocation. The structural cap is the arena ceiling of 2^_TLSF_FL_MAX, what
  * the mapping function can index, so a heap check that reused the allocation
@@ -1408,20 +1419,22 @@ static void coalesced_free_block_test(tlsf_t *t)
     tlsf_free(t, a);
     tlsf_free(t, b);
 
-    /* Without the merge clearing the bound this test proves nothing, so say so
-     * rather than passing quietly.
+    /* Without the merge this proves nothing. largest_free is clamped to
+     * TLSF_MAX_SIZE, hiding the merged size, so guard on 'each': only a block
+     * built from both neighbours clears a single one.
      */
     tlsf_stats_t stats;
     assert(tlsf_get_stats(t, &stats) == 0);
-    assert(stats.largest_free > bound);
+    assert(stats.largest_free > each);
+    assert_largest_free_allocatable(t, stats.largest_free);
 
     tlsf_check(t);
 
     tlsf_free(t, pin);
     tlsf_check(t);
 
-    printf("%zu-byte block from coalescing, above the %zu-byte bound, done\n",
-           stats.largest_free, bound);
+    printf("%zu-byte allocatable block from coalescing, done\n",
+           stats.largest_free);
 }
 
 /* The same defect by a second route: appending to a pool already at the
@@ -1463,14 +1476,48 @@ static void oversized_free_block_test(void)
     tlsf_stats_t stats;
     assert(tlsf_get_stats(&t, &stats) == 0);
     assert(stats.free_count == 1);
-    assert(stats.largest_free > TLSF_TEST_ALLOC_BOUND);
-    assert(stats.largest_free < ceiling);
+
+    /* free_count is 1, so total_free is that block. largest_free is clamped
+     * and cannot show that it exceeds any single allocation.
+     */
+    assert(stats.total_free > TLSF_MAX_SIZE);
+    assert(stats.total_free < ceiling);
+    assert(stats.largest_free <= TLSF_MAX_SIZE);
 
     tlsf_check(&t);
 
+    /* Reset rebuilds the same oversized free block after an append. */
+    tlsf_pool_reset(&t);
+    assert(tlsf_get_stats(&t, &stats) == 0);
+    assert_largest_free_allocatable(&t, stats.largest_free);
+
     free(mem);
-    printf("%zu-byte free block above the %zu-byte allocation bound, done\n",
-           stats.largest_free, (size_t) TLSF_TEST_ALLOC_BOUND);
+    printf("%zu-byte allocatable block after append/reset, done\n",
+           stats.largest_free);
+}
+
+/* Statistics must leave room for the allocator's second-level rounding. */
+static void largest_free_rounding_test(void)
+{
+    printf("Largest-free rounding test: ");
+    fflush(stdout);
+
+    /* The pool must already be ALIGN_SIZE-aligned. pool_init() would
+     * otherwise skip up to ALIGN_SIZE-1 bytes to align it and the expected
+     * figure below would move. A size_t array gives exactly that alignment;
+     * max_align_t would too, but MSVC does not declare it in C mode. 1056 is
+     * a multiple of sizeof(size_t) at both widths, so the span is exact.
+     */
+    size_t pool[1056 / sizeof(size_t)];
+    tlsf_t t;
+    assert(tlsf_pool_init(&t, pool, sizeof(pool)));
+
+    tlsf_stats_t stats;
+    assert(tlsf_get_stats(&t, &stats) == 0);
+    assert(stats.largest_free == 1024);
+    assert_largest_free_allocatable(&t, stats.largest_free);
+
+    puts("done");
 }
 
 /* A freed block must land in the bin that a same-size request will search, so
@@ -1675,6 +1722,7 @@ int main(void)
     pool_ceiling_test();
     oversized_free_block_test();
     coalesced_free_block_test(&t);
+    largest_free_rounding_test();
 
     /* Run argument contract test */
     argument_contract_test();

--- a/tests/wcet.c
+++ b/tests/wcet.c
@@ -170,6 +170,40 @@ static inline tick_t read_tick(void)
 }
 #endif
 
+/* Smallest non-zero step the counter reports, measured rather than assumed:
+ * on Apple Silicon read_tick() returns nanoseconds off a 24 MHz counter, so
+ * its real step is 42 ns while a malloc costs tens. Samples then collapse onto
+ * multiples of the step and every derived figure describes the clock. Knowing
+ * the step is what lets the report say so. Returns 0 if the counter is
+ * stopped.
+ */
+static tick_t tick_resolution(void)
+{
+    tick_t best = 0;
+
+    /* 64 trials: a minimum converges fast, and each trial spins for one tick
+     * period on a coarse counter, so the count is what makes this expensive.
+     */
+    for (int trial = 0; trial < 64; trial++) {
+        tick_t a = read_tick(), b = a;
+
+        /* Bounded, so a stopped counter ends the loop instead of hanging. */
+        for (int spin = 0; spin < 1000000 && b == a; spin++)
+            b = read_tick();
+        if (b == a)
+            return 0;
+
+        /* A read on another core can come back behind the first, making the
+         * unsigned difference near UINT64_MAX. Drop the trial: on the first
+         * one it would otherwise be taken outright, 'best' still being zero.
+         */
+        if (b > a && (!best || b - a < best))
+            best = b - a;
+    }
+
+    return best;
+}
+
 /* Statistics */
 
 static int cmp_tick(const void *a, const void *b)
@@ -655,15 +689,34 @@ int main(int argc, char **argv)
         fprintf(raw_fp, "scenario,size,unit,value\n");
     }
 
-    /* Header */
+    const tick_t resolution = tick_resolution();
+    bool zero_sample = false;
+
+    /* Header. The timer step belongs with the numbers in either mode, but CSV
+     * carries data rows only, so there it goes to stderr rather than into the
+     * columns.
+     */
+    if (!csv_mode) {
+        printf("TLSF WCET Analysis\n");
+        printf("==================\n");
+    }
+
+    /* CSV carries data rows only, so the step goes to stderr there rather than
+     * into the columns.
+     */
+    FILE *hdr = csv_mode ? stderr : stdout;
+    if (resolution)
+        fprintf(hdr, "Timer:      %s (step %" PRIu64 " %s, measured)\n",
+                TICK_UNIT, resolution, TICK_UNIT);
+    else
+        fprintf(hdr, "Timer:      %s (step unknown: counter did not advance)\n",
+                TICK_UNIT);
+
     if (csv_mode) {
         printf(
             "scenario,size,samples,unit,min,p50,p90,p99,p999,max,mean,"
             "stddev\n");
     } else {
-        printf("TLSF WCET Analysis\n");
-        printf("==================\n");
-        printf("Timer:      %s\n", TICK_UNIT);
         printf("Cache:      %s\n", thrash_buf ? "cold (64 MB thrash)" : "hot");
         printf("Pool:       %zu bytes (%.1f MB)\n", pool_size,
                (double) pool_size / (1024.0 * 1024.0));
@@ -700,6 +753,7 @@ int main(int argc, char **argv)
 
             latency_stats_t st;
             compute_latency_stats(samples, iterations, &st);
+            zero_sample |= st.min == 0;
 
             if (csv_mode) {
                 printf("%s,%zu,%zu,%s,%" PRIu64 ",%" PRIu64 ",%" PRIu64
@@ -755,6 +809,23 @@ int main(int argc, char **argv)
             printf("  %6zu %9.2fx %9.2fx\n", sz, malloc_ratio, free_ratio);
         }
         printf("\n");
+    }
+
+    /* A zero sample means the operation finished inside one step, so the
+     * counter cannot see it and the percentiles and ratios above are the
+     * counter's shape rather than the allocator's.
+     *
+     * The test is on the fastest sample, not the median, and needs no tuning
+     * constant.
+     */
+    if (resolution && zero_sample) {
+        fprintf(csv_mode ? stderr : stdout,
+                "WARNING: timer step %" PRIu64
+                " %s, and the fastest sample took zero.\n"
+                "         Operations complete inside one step, so the "
+                "percentiles and ratios\n"
+                "         above measure the clock, not the allocator.\n\n",
+                resolution, TICK_UNIT);
     }
 
     if (raw_fp)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
`largest_free` now reports a size `tlsf_malloc()` will actually serve — clamped to `TLSF_MAX_SIZE` and rounded down to a bin boundary — instead of the raw free block size that could exceed the limit and be rejected.

**Behavior changes**
- Oversized free blocks report the exact cap because flooring happens before capping, and a new rounding test pins the floor value for a known pool shape.
- Flooring and rounding share one bin-mask helper so the two directions cannot drift.
- Documentation explains why 4-byte alignment on 32-bit is the allocator's limit and points to `tlsf_aalloc()` for stricter guarantees.

**Verification and tooling**
- The `to_block()` assertion and `block_link()` contract now state only what the code needs, removing unprovable preconditions on the path to `block_link_next()`, and `floor_block_size` with `block_size_mask` are newly covered by WP (380 proved goals).
- New `check_negative` target drives one corrupted state per process, covering each `tlsf_check()` walk function, and requires both an abort and a `CHECK` diagnostic.
- Trim boundary test pins the inclusive split threshold so an off-by-one change fails the suite.
- WCET harness measures the timer step and warns when the fastest sample takes zero steps.
- cppcheck suppressions are scoped to files, and `*.gcov` output is ignored, so neither can silently go stale.

<sup>Written for commit ffaf4257539f17c641fc10911485af29ad6b04d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/tlsf-bsd/pull/43?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

