### PR TITLE
Fix problem of TLSF_THREAD_HINT

### DIFF
--- a/include/tlsf_thread.h
+++ b/include/tlsf_thread.h
@@ -215,9 +215,9 @@
 #ifdef TLSF_THREAD_LOCAL
 /* Offset on 12 bit is more correct here cause addresses will be different
  * only in least significant bits.
-*/
+ */
 #define TLSF_THREAD_HINT_AUX(x) \
-    ((x ^ ( x >> 12)))
+    ((unsigned) ((uintptr_t) x ^ ((uintptr_t) x >> 16)))
 #endif
 
 /* Number of independent arenas. Each arena has its own lock and TLSF pool, so N

--- a/include/tlsf_thread.h
+++ b/include/tlsf_thread.h
@@ -11,10 +11,14 @@
  *
  * Instead of a single coarse mutex around the entire allocator, the pool is
  * split into TLSF_ARENA_COUNT independent sub-pools (arenas), each with its own
- * lock. An allocation prefers the arena at mix(get_thread_hint()) modulo the
- * live arena count, so allocations from different threads usually hit different
- * locks. Nothing guarantees distinct arenas: hints can collide, and an arena
- * that is locked or full is skipped for another.
+ * lock. An allocation prefers the arena at mix(thread local variable address or
+ * optional by user TLSF_THREAD_HINT()) modulo the live arena count, so
+ * allocations from different threads usually hit different locks. Nothing
+ * guarantees distinct arenas: hints can collide, and an arena that is locked or
+ * full is skipped for another. Where thread local varibales øû not available or
+ * TLSF_THREAD_HINT() is not identified a thread it is the constant 0, which
+ * funnels every thread to arena 0 and forfeits the whole benefit; see the lock
+ * abstraction below.
  *
  * Thread-safety contract (same as POSIX malloc/free):
  * - Different threads may call any API function concurrently.
@@ -202,6 +206,10 @@
 #define TLSF_GCC_ALIGN(x)
 #endif
 
+/* Define here optional TLSF_THREAD_HINT()
+ * if thread local storage is not available.
+ */
+#if !defined(TLSF_THREAD_HINT)
 #if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
 #define TLSF_THREAD_LOCAL thread_local
 #elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
@@ -211,12 +219,10 @@
 #elif defined(_MSC_VER)
 #define TLSF_THREAD_LOCAL __declspec(thread)
 #endif
+#endif
 
 #ifdef TLSF_THREAD_LOCAL
-/* Offset on 12 bit is more correct here cause addresses will be different
- * only in least significant bits.
- */
-#define TLSF_THREAD_HINT_AUX(x) \
+#define TLSF_THREAD_SHIFTXOR(x) \
     ((unsigned) ((uintptr_t) x ^ ((uintptr_t) x >> 16)))
 #endif
 

--- a/include/tlsf_thread.h
+++ b/include/tlsf_thread.h
@@ -11,12 +11,10 @@
  *
  * Instead of a single coarse mutex around the entire allocator, the pool is
  * split into TLSF_ARENA_COUNT independent sub-pools (arenas), each with its own
- * lock. An allocation prefers the arena at mix(TLSF_THREAD_HINT()) modulo the
+ * lock. An allocation prefers the arena at mix(get_thread_hint()) modulo the
  * live arena count, so allocations from different threads usually hit different
  * locks. Nothing guarantees distinct arenas: hints can collide, and an arena
- * that is locked or full is skipped for another. Where TLSF_THREAD_HINT()
- * cannot identify a thread it is the constant 0, which funnels every thread to
- * arena 0 and forfeits the whole benefit; see the lock abstraction below.
+ * that is locked or full is skipped for another.
  *
  * Thread-safety contract (same as POSIX malloc/free):
  * - Different threads may call any API function concurrently.
@@ -43,11 +41,7 @@
 
 /* Lock abstraction
  *
- * Override ALL six lock macros together before including this header. When
- * providing custom locks, also define TLSF_THREAD_HINT() to return a
- * thread-specific unsigned integer for arena selection. Without it the hint
- * falls back to the constant 0, every thread selects arena 0, and the per-arena
- * locking degenerates to a single lock.
+ * Override ALL six lock macros together before including this header.
  *
  * TLSF_LOCK_INIT must evaluate to an int: 0 on success, non-zero on failure.
  * tlsf_thread_init() checks it and aborts initialization if a lock cannot be
@@ -61,7 +55,6 @@
  *   #define TLSF_LOCK_ACQUIRE(l)  xSemaphoreTake(*(l), portMAX_DELAY)
  *   #define TLSF_LOCK_RELEASE(l)  xSemaphoreGive(*(l))
  *   #define TLSF_LOCK_TRY(l)      (xSemaphoreTake(*(l),0)==pdTRUE)
- *   #define TLSF_THREAD_HINT()    ((unsigned)uxTaskGetTaskNumber(NULL))
  *   #include "tlsf_thread.h"
  */
 
@@ -222,8 +215,9 @@
 #ifdef TLSF_THREAD_LOCAL
 /* Offset on 12 bit is more correct here cause addresses will be different
  * only in least significant bits.
- */
-#define TLSF_THREAD_HINT_AUX(x) ((x ^ (x >> 12)))
+*/
+#define TLSF_THREAD_HINT_AUX(x) \
+    ((x ^ ( x >> 12)))
 #endif
 
 /* Number of independent arenas. Each arena has its own lock and TLSF pool, so N

--- a/include/tlsf_thread.h
+++ b/include/tlsf_thread.h
@@ -221,11 +221,6 @@
 #endif
 #endif
 
-#ifdef TLSF_THREAD_LOCAL
-#define TLSF_THREAD_SHIFTXOR(x) \
-    ((unsigned) ((uintptr_t) x ^ ((uintptr_t) x >> 16)))
-#endif
-
 /* Number of independent arenas. Each arena has its own lock and TLSF pool, so N
  * arenas support up to N contention-free concurrent allocations.
  *

--- a/include/tlsf_thread.h
+++ b/include/tlsf_thread.h
@@ -196,42 +196,7 @@
 #define TLSF_LOCK_TRY(l) (pthread_mutex_trylock((l)) == 0)
 #endif
 
-/* Fold upper bits into lower 32 to retain entropy on 64-bit systems. */
-#ifndef TLSF_THREAD_HINT
-#if defined(_TLSF_USE_C11_THREADS)
-#if defined(TLSF_THREAD_WIN)
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif
-#include <windows.h>
-#define TLSF_THREAD_HINT() ((unsigned) GetCurrentThreadId())
-#elif defined(TLSF_THREAD_POSIX)
-#include <pthread.h>
-#define TLSF_THREAD_HINT()                    \
-    ((unsigned) ((uintptr_t) pthread_self() ^ \
-                 ((uintptr_t) pthread_self() >> 16)))
-#else
-#define TLSF_THREAD_HINT()                    \
-    ((unsigned) ((uintptr_t) thrd_current() ^ \
-                 ((uintptr_t) thrd_current() >> 16)))
-#endif
-#elif defined(TLSF_THREAD_POSIX)
-#define TLSF_THREAD_HINT()                    \
-    ((unsigned) ((uintptr_t) pthread_self() ^ \
-                 ((uintptr_t) pthread_self() >> 16)))
-#elif defined(TLSF_THREAD_WIN)
-#define TLSF_THREAD_HINT() ((unsigned) GetCurrentThreadId())
-#else
-#define TLSF_THREAD_HINT() 0U
-#endif
-#endif
-
 #endif /* TLSF_LOCK_T */
-
-/* Fallback thread hint for custom locks without a custom hint. */
-#ifndef TLSF_THREAD_HINT
-#define TLSF_THREAD_HINT() 0U
-#endif
 
 #if defined(_MSC_VER)
 #define TLSF_MSVC_ALIGN(x) __declspec(align(x))
@@ -242,6 +207,23 @@
 #else
 #define TLSF_MSVC_ALIGN(x)
 #define TLSF_GCC_ALIGN(x)
+#endif
+
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
+#define TLSF_THREAD_LOCAL thread_local
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+#define TLSF_THREAD_LOCAL _Thread_local
+#elif defined(__GNUC__) || defined(__clang__)
+#define TLSF_THREAD_LOCAL __thread
+#elif defined(_MSC_VER)
+#define TLSF_THREAD_LOCAL __declspec(thread)
+#endif
+
+#ifdef TLSF_THREAD_LOCAL
+/* Offset on 12 bit is more correct here cause addresses will be different
+ * only in least significant bits.
+ */
+#define TLSF_THREAD_HINT_AUX(x) ((x ^ (x >> 12)))
 #endif
 
 /* Number of independent arenas. Each arena has its own lock and TLSF pool, so N

--- a/include/tlsf_thread.h
+++ b/include/tlsf_thread.h
@@ -15,7 +15,7 @@
  * optional by user TLSF_THREAD_HINT()) modulo the live arena count, so
  * allocations from different threads usually hit different locks. Nothing
  * guarantees distinct arenas: hints can collide, and an arena that is locked or
- * full is skipped for another. Where thread local varibales øû not available or
+ * full is skipped for another. Where thread local varibales is not available or
  * TLSF_THREAD_HINT() is not identified a thread it is the constant 0, which
  * funnels every thread to arena 0 and forfeits the whole benefit; see the lock
  * abstraction below.
@@ -210,7 +210,9 @@
  * if thread local storage is not available.
  */
 #if !defined(TLSF_THREAD_HINT)
-#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
+#if defined(_MSC_VER) && _MSC_VER < 1938
+#define TLSF_THREAD_LOCAL __declspec(thread)
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
 #define TLSF_THREAD_LOCAL thread_local
 #elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
 #define TLSF_THREAD_LOCAL _Thread_local

--- a/src/tlsf_thread.c
+++ b/src/tlsf_thread.c
@@ -14,6 +14,21 @@
 
 #include "tlsf_thread.h"
 
+/* Local for each thread id */
+#ifdef TLSF_THREAD_LOCAL
+static TLSF_THREAD_LOCAL unsigned int tlsf_thread_id = 0;
+#endif
+
+static inline unsigned int get_thread_hint(void)
+{
+#ifdef TLSF_THREAD_HINT_AUX
+    unsigned int thread_unique_address = (uintptr_t) (&tlsf_thread_id);
+    return TLSF_THREAD_HINT_AUX(thread_unique_address);
+#else
+    return 0U;
+#endif
+}
+
 /* Hash the thread hint to select a preferred arena.
  *
  * The mixing function distributes thread IDs that may differ only in their low
@@ -21,7 +36,7 @@
  */
 static inline int arena_select(const tlsf_thread_t *ts)
 {
-    unsigned h = TLSF_THREAD_HINT();
+    unsigned h = get_thread_hint();
     h ^= h >> 16;
     h *= 0x45d9f3bU;
     h ^= h >> 16;

--- a/src/tlsf_thread.c
+++ b/src/tlsf_thread.c
@@ -15,15 +15,17 @@
 #include "tlsf_thread.h"
 
 /* Local for each thread id */
-#ifdef TLSF_THREAD_LOCAL
+#if defined(TLSF_THREAD_LOCAL) && !defined(TLSF_THREAD_HINT)
 static TLSF_THREAD_LOCAL unsigned int tlsf_thread_id = 0;
 #endif
 
 static inline unsigned int get_thread_hint(void)
 {
-#ifdef TLSF_THREAD_HINT_AUX
+#if defined(TLSF_THREAD_SHIFTXOR)
     uintptr_t thread_unique_address = (uintptr_t) (&tlsf_thread_id);
-    return TLSF_THREAD_HINT_AUX(thread_unique_address);
+    return TLSF_THREAD_SHIFTXOR(thread_unique_address);
+#elif defined(TLSF_THREAD_HINT)
+    return TLSF_THREAD_HINT();
 #else
     return 0U;
 #endif

--- a/src/tlsf_thread.c
+++ b/src/tlsf_thread.c
@@ -22,7 +22,7 @@ static TLSF_THREAD_LOCAL unsigned int tlsf_thread_id = 0;
 static inline unsigned int get_thread_hint(void)
 {
 #ifdef TLSF_THREAD_HINT_AUX
-    unsigned int thread_unique_address = (uintptr_t) (&tlsf_thread_id);
+    uintptr_t thread_unique_address = (uintptr_t) (&tlsf_thread_id);
     return TLSF_THREAD_HINT_AUX(thread_unique_address);
 #else
     return 0U;

--- a/src/tlsf_thread.c
+++ b/src/tlsf_thread.c
@@ -21,9 +21,8 @@ static TLSF_THREAD_LOCAL unsigned int tlsf_thread_id = 0;
 
 static inline unsigned int get_thread_hint(void)
 {
-#if defined(TLSF_THREAD_SHIFTXOR)
-    uintptr_t thread_unique_address = (uintptr_t) (&tlsf_thread_id);
-    return TLSF_THREAD_SHIFTXOR(thread_unique_address);
+#if defined(TLSF_THREAD_LOCAL)
+    return (unsigned) ((uintptr_t) &tlsf_thread_id);
 #elif defined(TLSF_THREAD_HINT)
     return TLSF_THREAD_HINT();
 #else


### PR DESCRIPTION
TLSF_THREAD_HINT is problematic.
The main problem is in this operation:
```c
((unsigned) ((uintptr_t) pthread_self() ^ \
                 ((uintptr_t) pthread_self() >> 16)))
```

or
```c
((unsigned) ((uintptr_t) thrd_current() ^ \
                 ((uintptr_t) thrd_current() >> 16))).
```

Thread objects in pthreads and in C11 threads are opaque types. Its can be addresses or structures.
In case if it is structure this macro can not be compiled successfully.
The main idea of the solution is thread local variable has unique addresses for each thread.
This PR adds thread local variable and uses its address for the same purpose.
This is simlpler and theoretically faster cause pthread_self() / thrd_current() / GetCurrentThreadId()
executes many operations in their inner implementations.
In this PR right offset 16 is replaced by 12 cause thread local variables are neighbours in memory
and their addresses have differences only in least significant bits.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the `TLSF_THREAD_HINT()` macro with the address of a thread-local variable for arena selection, so builds no longer depend on opaque thread functions (`pthread_self`, `thrd_current`) that can be structs and break compilation, and avoids their runtime cost.

- Uses a static thread-local `unsigned int`'s address, cast via `uintptr_t` to avoid a `-Wconversion` warning.
- Drops the old xor/shift folding; thread-local addresses differ in low bits that `arena_select`'s mixer already spreads.
- A user's `TLSF_THREAD_HINT()` is honored only when the compiler lacks thread-local storage; otherwise constant 0 preserves the single-arena fallback.
- Adds a `TLSF_THREAD_LOCAL` detection macro (C23 `thread_local`, C11 `_Thread_local`, GCC/Clang `__thread`, and MSVC `__declspec(thread)` before version 1938) and removes the old macro from the header.

<sup>Written for commit 8a2edbb2424df95538f5b13636f2fd4c4af22ba7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/tlsf-bsd/pull/44?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



