### PR TITLE
Run proves the behavior each test names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,9 +174,18 @@ check: $(TARGETS) $(THREAD_TARGETS) $(CPP_TARGETS) check-negative
 	./build/test_thread
 	./build/test_cpp
 
-# Each case must abort with a CHECK diagnostic, not a segfault that looks like
-# one. Two ways this fails open, both closed here: a fixture broken in seed()
-# would abort every case alike, so the control run goes first; a build without
+# Each case must abort with the CHECK diagnostic it names, not with a segfault
+# that looks like one and not with some other check that happens to fire first.
+# The driver prints the expected message under -e, so the two halves of a case
+# cannot drift apart without this failing.
+#
+# The trailing separator in the pattern below is what makes the message whole
+# rather than a prefix of it. Without it a case naming "prev_free bit mismatch"
+# would also accept "sentinel prev_free bit mismatch", which is a different
+# check in a different walk.
+#
+# Two ways this fails open, both closed here: a fixture broken in seed() would
+# abort every case alike, so the control run goes first; a build without
 # TLSF_ENABLE_CHECK has no rejection to observe, so the driver reports zero
 # cases and this skips. The count arrives as an exit status, so a driver that
 # dies at startup yields a number past the last case, which the driver itself
@@ -194,14 +203,18 @@ check-negative: $(OUT)/check_negative
 	fi; \
 	i=0; \
 	while [ "$$i" -lt "$$n" ]; do \
+		if ! want=$$(./$(OUT)/check_negative -e $$i 2>&1); then \
+			echo "check_negative: case $$i has no expected message:" >&2; \
+			echo "$$want" >&2; exit 1; \
+		fi; \
 		if out=$$(./$(OUT)/check_negative $$i 2>&1); then \
 			echo "check_negative: case $$i accepted by tlsf_check()" >&2; \
 			exit 1; \
 		fi; \
 		case "$$out" in \
-		*"TLSF CHECK:"*) ;; \
-		*) echo "check_negative: case $$i failed with no CHECK diagnostic:" \
-			>&2; echo "$$out" >&2; exit 1 ;; \
+		*"TLSF CHECK: $$want - "*) ;; \
+		*) echo "check_negative: case $$i wanted \"$$want\", got:" >&2; \
+			echo "$$out" >&2; exit 1 ;; \
 		esac; \
 		i=$$((i + 1)); \
 	done; \

--- a/tests/check_negative.c
+++ b/tests/check_negative.c
@@ -8,20 +8,48 @@
  *
  * Every other call of it in the suite expects it to pass, which proves only
  * that it accepts valid states: gutting the body to '(void) t;' left both
- * tests/test.c and tests/test_thread.c green. One case per walk function, so
- * dropping any of the three fails here.
+ * tests/test.c and tests/test_thread.c green.
  *
- *   case 0  null allocator              tlsf_check() itself
- *   case 1  arena size disagrees        check_block_chain()
- *   case 2  bitmap bit claims an
- *           empty bin                   check_free_lists()
- *   case 3  free-list back link points
- *           at the wrong block          check_bin_list()
+ * Each case below corrupts one state so that exactly one CHECK() site in
+ * 'src/tlsf.c' fires, and carries the diagnostic it must produce. Matching the
+ * message is what makes the count meaningful: a corruption that trips some
+ * earlier CHECK still aborts, so a runner that only looked for an abort would
+ * report coverage this file does not have.
+ *
+ * The sites left without a case are unreachable rather than omitted. They are
+ * named here with the reason:
+ *
+ *   block size not aligned         tautological. block_size() returns
+ *                                  'header - header % ALIGN_SIZE', so what it
+ *                                  returns is aligned whatever the header
+ *                                  holds. This is also why a case cannot reach
+ *                                  the alignment entries below it.
+ *   block pointer not aligned      a block's address is the arena base plus
+ *   payload not aligned            the sizes walked so far, all of them
+ *                                  aligned by the line above, so an unaligned
+ *                                  one needs an unaligned arena, which is
+ *                                  rejected before the walk starts.
+ *   free block below minimum size  phase 1 walks every block, including this
+ *   free block has free            one, and rejects an undersized or
+ *     predecessor                  uncoalesced block before phase 2 reaches
+ *   free block has free successor  the bin lists.
+ *   next block doesn't know this
+ *     block is free
+ *   free list next pointer         tautological. 'list_block' was assigned
+ *     incorrect                    'list_prev->next_free' at the bottom of the
+ *                                  previous iteration and nothing writes to
+ *                                  the list in between, so the comparison
+ *                                  cannot fail.
  *
  * CHECK() aborts, so each case needs its own process; the Makefile runner
  * drives them by index and asserts both the abort and the diagnostic. Case -1
  * corrupts nothing and must exit cleanly, or a harness broken for its own
  * reasons would look like success on every case.
+ *
+ * That abort also keeps these cases out of 'make coverage': gcov flushes its
+ * counters at exit and abort() does not run that, so every CHECK failure edge
+ * reads as never taken however many are exercised here. The count this program
+ * prints is the measure; the coverage report is not.
  */
 
 #include <stdio.h>
@@ -31,29 +59,130 @@
 
 #include "pool_limits.h"
 
-/* Without TLSF_ENABLE_CHECK there is no rejection to observe, so report no
- * cases and let the runner skip rather than pass vacuously.
+/* Mirror of the block encoding in 'src/tlsf.c'. The struct is public, the
+ * constants that interpret its header word are not, so they are restated here
+ * and checked against a live pool by mirror_selfcheck() before any case runs. A
+ * silently wrong mirror would corrupt something other than what the case names,
+ * which is the one way this file could report coverage it lacks.
  */
-#ifdef TLSF_ENABLE_CHECK
-#define CASE_COUNT 4
-#else
-#define CASE_COUNT 0
-#endif
+#define BLK_FREE ((size_t) 1)
+#define BLK_PREV_FREE ((size_t) 2)
+#define BLK_BITS (BLK_FREE | BLK_PREV_FREE)
+#define BLK_OVERHEAD (sizeof(size_t))
+#define BLK_ALIGN (sizeof(size_t))
+#define BLK_SIZE_MIN (sizeof(struct tlsf_block) - sizeof(struct tlsf_block *))
 
-static char pool[TLSF_TEST_POOL_CLAMP(64 * 1024)];
+/* The size occupies everything above the alignment shift, which is a wider
+ * field than the status bits sit in. That gap is why a misaligned block size
+ * cannot be expressed at all.
+ */
+static size_t blk_size(const struct tlsf_block *b)
+{
+    return b->header - b->header % BLK_ALIGN;
+}
 
-/* Occupy several bins, so the bitmap and free-list cases have targets. */
+static bool blk_is_free(const struct tlsf_block *b)
+{
+    return (b->header & BLK_FREE) != 0;
+}
+
+static bool blk_is_prev_free(const struct tlsf_block *b)
+{
+    return (b->header & BLK_PREV_FREE) != 0;
+}
+
+static struct tlsf_block *blk_next(struct tlsf_block *b)
+{
+    char *payload = (char *) b + sizeof(struct tlsf_block *) + BLK_OVERHEAD;
+    return (struct tlsf_block *) (payload + blk_size(b) - BLK_OVERHEAD);
+}
+
+/* The first block starts one header word below the arena: a block's 'prev'
+ * field precedes its header, and for the first block that field lies outside
+ * the arena.
+ */
+static struct tlsf_block *blk_first(const tlsf_t *t)
+{
+    return (struct tlsf_block *) ((char *) t->arena - BLK_OVERHEAD);
+}
+
+static void die(const char *what)
+{
+    fprintf(stderr, "check_negative: %s\n", what);
+    exit(2);
+}
+
+/* Walk to the zero-size block that terminates the chain. */
+static struct tlsf_block *blk_sentinel(const tlsf_t *t)
+{
+    struct tlsf_block *b = blk_first(t);
+    while (blk_size(b))
+        b = blk_next(b);
+    return b;
+}
+
+/* A free block whose physical successor is a real block rather than the
+ * sentinel, so a case can corrupt the pair.
+ */
+static struct tlsf_block *blk_free_with_successor(const tlsf_t *t)
+{
+    struct tlsf_block *b = blk_first(t);
+    while (blk_size(b)) {
+        struct tlsf_block *next = blk_next(b);
+        if (blk_is_free(b) && blk_size(next))
+            return b;
+        b = blk_next(b);
+    }
+    die("fixture has no free block with a successor");
+    return NULL;
+}
+
+/* Lowest first-level index with a clear bit. */
+static uint32_t first_clear_fl(const tlsf_t *t)
+{
+    uint32_t i = 0;
+    while (i < _TLSF_FL_COUNT && (t->fl & (1U << i)))
+        i++;
+    if (i >= _TLSF_FL_COUNT)
+        die("no clear FL bit to set");
+    return i;
+}
+
+/* The list head of the 'n'th non-empty bin. Returned by address because most
+ * cases rewrite the head rather than read it.
+ */
+static struct tlsf_block **nth_bin_head(tlsf_t *t, size_t n)
+{
+    for (uint32_t i = 0; i < _TLSF_FL_COUNT; i++) {
+        for (uint32_t j = 0; j < _TLSF_SL_COUNT; j++) {
+            if (t->block[i][j] != &t->block_null && !n--)
+                return &t->block[i][j];
+        }
+    }
+    die("fixture left too few non-empty bins");
+    return NULL;
+}
+
+/* Non-null and not the free-list sentinel, which is all the bitmap cases below
+ * need: tlsf_check() compares the pointer and aborts without following it.
+ */
+static struct tlsf_block decoy;
+
+/* Occupy one bin several times over and leave a large tail, so the free-list
+ * cases have both a multi-block bin and a second non-empty bin to work with.
+ * The kept blocks vary in size only to spread the holes; the dropped ones are
+ * all one size on purpose, because equal sizes land in one bin and unequal ones
+ * would not.
+ */
 static void seed(tlsf_t *t)
 {
     void *live[8], *dead[8];
 
     for (size_t i = 0; i < 8; i++) {
         live[i] = tlsf_malloc(t, 32 + i * 64);
-        dead[i] = tlsf_malloc(t, 48 + i * 96);
-        if (!live[i] || !dead[i]) {
-            fprintf(stderr, "check_negative: seed allocation failed\n");
-            exit(2);
-        }
+        dead[i] = tlsf_malloc(t, 96);
+        if (!live[i] || !dead[i])
+            die("seed allocation failed");
     }
 
     /* Allocated alternately, so freeing one array leaves holes the survivors
@@ -65,25 +194,268 @@ static void seed(tlsf_t *t)
     tlsf_check(t); /* the fixture itself must be valid */
 }
 
-/* Lowest first-level index with a clear bit, else _TLSF_FL_COUNT. */
-static uint32_t first_clear_fl(const tlsf_t *t)
+/* Confirm the header mirror above agrees with the allocator, so a case that
+ * flips a bit flips the bit it names.
+ */
+static void mirror_selfcheck(const tlsf_t *t)
 {
-    uint32_t i = 0;
-    while (i < _TLSF_FL_COUNT && (t->fl & (1U << i)))
-        i++;
-    return i;
+    size_t total = 0, seen_free = 0;
+    struct tlsf_block *b = blk_first(t);
+
+    while (blk_size(b)) {
+        if (blk_size(b) < BLK_SIZE_MIN || blk_size(b) % BLK_ALIGN)
+            die("mirror disagrees on block size encoding");
+
+        /* Nothing but the status bits may live under the mask, or the flag
+         * constants above name the wrong bits.
+         */
+        if (b->header % BLK_ALIGN > BLK_BITS)
+            die("mirror disagrees on the status bits");
+        seen_free += blk_is_free(b);
+        total += blk_size(b) + BLK_OVERHEAD;
+        b = blk_next(b);
+    }
+    total += BLK_OVERHEAD;
+
+    /* Reaching the sentinel with the right total means the size mask, the
+     * overhead and the payload offset are all right.
+     */
+    if (total != t->size)
+        die("mirror disagrees on the block chain layout");
+    if (!seen_free)
+        die("mirror disagrees on the free bit");
+
+    /* seed() left holes between live blocks, so a free block must have a used
+     * predecessor whose successor bit says so.
+     */
+    b = blk_free_with_successor(t);
+    if (!blk_is_prev_free(blk_next(b)))
+        die("mirror disagrees on the prev-free bit");
 }
 
-/* A block sitting on some free list, or NULL if the fixture left none. */
-static struct tlsf_block *any_free_block(tlsf_t *t)
+static void corrupt_null_allocator(tlsf_t *t)
+{
+    (void) t;
+    tlsf_check(NULL);
+}
+
+static void corrupt_arena_null(tlsf_t *t)
+{
+    t->arena = NULL;
+}
+
+static void corrupt_arena_unaligned(tlsf_t *t)
+{
+    t->arena = (char *) t->arena + 1;
+}
+
+static void corrupt_block_undersized(tlsf_t *t)
+{
+    struct tlsf_block *b = blk_first(t);
+    b->header = (b->header & BLK_BITS) | BLK_ALIGN;
+}
+
+static void corrupt_block_oversized(tlsf_t *t)
+{
+    struct tlsf_block *b = blk_first(t);
+    b->header = (b->header & BLK_BITS) | ((size_t) 1 << _TLSF_FL_MAX);
+}
+
+static void corrupt_prev_free_bit(tlsf_t *t)
+{
+    /* The first block has no predecessor to disagree with, so use the one after
+     * it.
+     */
+    struct tlsf_block *b = blk_next(blk_first(t));
+    b->header ^= BLK_PREV_FREE;
+}
+
+static void corrupt_prev_pointer(tlsf_t *t)
+{
+    /* Only consulted where the predecessor is free, so corrupt the successor of
+     * a free block. Its own address is a valid pointer and the wrong value.
+     */
+    struct tlsf_block *b = blk_next(blk_free_with_successor(t));
+    b->prev = b;
+}
+
+static void corrupt_consecutive_free(tlsf_t *t)
+{
+    struct tlsf_block *b = blk_next(blk_free_with_successor(t));
+    b->header |= BLK_FREE;
+}
+
+static void corrupt_sentinel_free(tlsf_t *t)
+{
+    blk_sentinel(t)->header |= BLK_FREE;
+}
+
+static void corrupt_sentinel_prev_free_bit(tlsf_t *t)
+{
+    blk_sentinel(t)->header ^= BLK_PREV_FREE;
+}
+
+static void corrupt_sentinel_prev_pointer(tlsf_t *t)
+{
+    struct tlsf_block *s = blk_sentinel(t);
+    if (!blk_is_prev_free(s))
+        die("fixture does not end in a free block");
+    s->prev = s;
+}
+
+static void corrupt_size_sum(tlsf_t *t)
+{
+    /* One alignment unit breaks the size reconciliation and leaves every
+     * pointer valid, so the walk reaches it.
+     */
+    t->size += BLK_ALIGN;
+}
+
+static void corrupt_sl_without_fl(tlsf_t *t)
+{
+    t->sl[first_clear_fl(t)] = 1;
+}
+
+static void corrupt_bin_without_fl(tlsf_t *t)
+{
+    t->block[first_clear_fl(t)][0] = &decoy;
+}
+
+static void corrupt_fl_without_sl(tlsf_t *t)
+{
+    t->fl |= 1U << first_clear_fl(t);
+}
+
+static void corrupt_bin_without_sl(tlsf_t *t)
 {
     for (uint32_t i = 0; i < _TLSF_FL_COUNT; i++) {
+        if (!(t->fl & (1U << i)))
+            continue;
         for (uint32_t j = 0; j < _TLSF_SL_COUNT; j++) {
-            if (t->block[i][j] != &t->block_null)
-                return t->block[i][j];
+            if (!(t->sl[i] & (1U << j))) {
+                t->block[i][j] = &decoy;
+                return;
+            }
         }
     }
-    return NULL;
+    die("no clear SL bit in an occupied first level");
+}
+
+static void corrupt_bin_empty_with_sl(tlsf_t *t)
+{
+    *nth_bin_head(t, 0) = &t->block_null;
+}
+
+static void corrupt_listed_block_not_free(tlsf_t *t)
+{
+    /* Clear the successor's prev-free bit too, or phase 1 rejects the pair
+     * before phase 2 walks the bin.
+     */
+    struct tlsf_block *b = *nth_bin_head(t, 0);
+    b->header &= ~BLK_FREE;
+    blk_next(b)->header &= ~BLK_PREV_FREE;
+}
+
+static void corrupt_block_in_wrong_bin(tlsf_t *t)
+{
+    struct tlsf_block **a = nth_bin_head(t, 0);
+    struct tlsf_block **b = nth_bin_head(t, 1);
+    struct tlsf_block *tmp = *a;
+
+    /* Two bins of different sizes, so each head now maps to the other bin. */
+    *a = *b;
+    *b = tmp;
+}
+
+static void corrupt_free_list_prev(tlsf_t *t)
+{
+    /* A list head must point back at the sentinel. Point it at itself: a valid
+     * address, wrong value.
+     */
+    struct tlsf_block *b = *nth_bin_head(t, 0);
+    b->prev_free = b;
+}
+
+static void corrupt_free_list_cycle(tlsf_t *t)
+{
+    struct tlsf_block *b = *nth_bin_head(t, 0);
+    b->next_free = b;
+}
+
+static void corrupt_free_count(tlsf_t *t)
+{
+    /* Drop the head off its list without touching the physical chain, so the
+     * two walks count different numbers of free blocks. seed() fills this bin
+     * with more than one block, so it stays non-empty and its bitmap bits stay
+     * honest.
+     */
+    struct tlsf_block **head = nth_bin_head(t, 0);
+    struct tlsf_block *second = (*head)->next_free;
+
+    if (second == &t->block_null)
+        die("fixture bin holds only one block");
+    second->prev_free = &t->block_null;
+    *head = second;
+}
+
+/* Pairing the diagnostic with the corruption is what keeps the two in step: a
+ * case whose corruption drifts onto another check fails on the message rather
+ * than passing on the abort. Each string is the whole message, not a prefix of
+ * it, because the runner anchors on the separator that follows: one CHECK
+ * message is a suffix of another, so a prefix would match both.
+ */
+static const struct {
+    const char *want;
+    void (*corrupt)(tlsf_t *t);
+} cases[] = {
+    {"tlsf_t pointer is null", corrupt_null_allocator},
+    {"failed to get arena pointer", corrupt_arena_null},
+    {"arena not aligned", corrupt_arena_unaligned},
+    {"block smaller than minimum size", corrupt_block_undersized},
+    {"block exceeds mapping range", corrupt_block_oversized},
+    {"prev_free bit mismatch with actual previous block state",
+     corrupt_prev_free_bit},
+    {"prev pointer doesn't match previous block", corrupt_prev_pointer},
+    {"consecutive free blocks (coalescing failed)", corrupt_consecutive_free},
+    {"sentinel marked as free", corrupt_sentinel_free},
+    {"sentinel prev_free bit mismatch", corrupt_sentinel_prev_free_bit},
+    {"sentinel prev pointer incorrect", corrupt_sentinel_prev_pointer},
+    {"block sizes don't sum to pool size", corrupt_size_sum},
+    {"SL bitmap non-zero but FL bit is clear", corrupt_sl_without_fl},
+    {"block pointer not sentinel but FL bit is clear", corrupt_bin_without_fl},
+    {"FL bit set but SL bitmap is empty", corrupt_fl_without_sl},
+    {"block pointer not sentinel but SL bit is clear", corrupt_bin_without_sl},
+    {"SL bit set but block list is empty (sentinel)",
+     corrupt_bin_empty_with_sl},
+    {"block in free list not free", corrupt_listed_block_not_free},
+    {"block in wrong FL/SL bin", corrupt_block_in_wrong_bin},
+    {"free list prev pointer incorrect", corrupt_free_list_prev},
+    {"cycle in free list (duplicate block / double-free?)",
+     corrupt_free_list_cycle},
+    {"free block count mismatch between block walk and free list walk",
+     corrupt_free_count},
+};
+
+/* Without TLSF_ENABLE_CHECK there is no rejection to observe, so offer no cases
+ * and let the runner skip rather than pass vacuously.
+ */
+#ifdef TLSF_ENABLE_CHECK
+#define CASE_COUNT ((int) (sizeof(cases) / sizeof(cases[0])))
+#else
+#define CASE_COUNT 0
+#endif
+
+static char pool[TLSF_TEST_POOL_CLAMP(64 * 1024)];
+
+static long parse_case(const char *s)
+{
+    char *end;
+    const long which = strtol(s, &end, 10);
+    if (*end || end == s) {
+        fprintf(stderr, "check_negative: not a case number: %s\n", s);
+        exit(2);
+    }
+    return which;
 }
 
 int main(int argc, char **argv)
@@ -92,72 +464,44 @@ int main(int argc, char **argv)
      * the shell already guarantees is a small integer, so the runner needs no
      * parsing and no validation of what it parsed.
      */
-    if (argc != 2)
+    if (argc == 1)
         return CASE_COUNT;
 
-    char *end;
-    const long which = strtol(argv[1], &end, 10);
-    if (*end || end == argv[1]) {
-        fprintf(stderr, "check_negative: not a case number: %s\n", argv[1]);
-        return 2;
-    }
-
-    /* Needs no pool, so it runs before one exists. */
-    if (which == 0) {
-        tlsf_check(NULL);
-        fprintf(stderr, "check_negative: case 0 returned\n");
-        return 1;
-    }
-
-    tlsf_t t;
-    if (!tlsf_pool_init(&t, pool, sizeof(pool))) {
-        fprintf(stderr, "check_negative: pool init failed\n");
-        return 2;
-    }
-    seed(&t);
-
-    switch (which) {
-    case -1: /* control: seed() already checked the untouched fixture */
+    /* The expected diagnostic goes out on its own, before the run that aborts,
+     * because the runner has to know what to look for in output it has not
+     * received yet.
+     */
+    if (argc == 3 && argv[1][0] == '-' && argv[1][1] == 'e' && !argv[1][2]) {
+        const long which = parse_case(argv[2]);
+        if (which < 0 || which >= CASE_COUNT) {
+            fprintf(stderr, "check_negative: no such case: %s\n", argv[2]);
+            return 2;
+        }
+        printf("%s\n", cases[which].want);
         return 0;
-
-    case 1:
-        /* One alignment unit breaks the size reconciliation and leaves every
-         * pointer valid, so the walk reaches it.
-         */
-        t.size += sizeof(size_t);
-        break;
-
-    case 2: {
-        /* A first-level bit over an empty second-level bitmap. Bins untouched,
-         * so nothing new is dereferenced.
-         */
-        uint32_t fl = first_clear_fl(&t);
-        if (fl >= _TLSF_FL_COUNT) {
-            fprintf(stderr, "check_negative: no clear FL bit to set\n");
-            return 2;
-        }
-        t.fl |= 1U << fl;
-        break;
     }
 
-    case 3: {
-        /* A list head must point back at the sentinel. Point it at itself: a
-         * valid address, wrong value.
-         */
-        struct tlsf_block *block = any_free_block(&t);
-        if (!block) {
-            fprintf(stderr, "check_negative: fixture left no free block\n");
-            return 2;
-        }
-        block->prev_free = block;
-        break;
+    if (argc != 2) {
+        fprintf(stderr, "check_negative: usage: %s [-e] [case]\n", argv[0]);
+        return 2;
     }
 
-    default:
+    const long which = parse_case(argv[1]);
+    if (which < -1 || which >= CASE_COUNT) {
         fprintf(stderr, "check_negative: no such case: %s\n", argv[1]);
         return 2;
     }
 
+    tlsf_t t;
+    if (!tlsf_pool_init(&t, pool, sizeof(pool)))
+        die("pool init failed");
+    seed(&t);
+    mirror_selfcheck(&t);
+
+    if (which == -1) /* control: seed() already checked the untouched fixture */
+        return 0;
+
+    cases[which].corrupt(&t);
     tlsf_check(&t);
 
     /* Reached only when tlsf_check() accepted a state it must reject. */

--- a/tests/test.c
+++ b/tests/test.c
@@ -223,26 +223,53 @@ static void random_test(tlsf_t *t, size_t spacelen, const size_t cap)
         assert(p[i]);
         rest -= (int64_t) len;
 
+        /* Tag the whole usable extent, not just one byte, and do it before the
+         * realloc below rather than after: a fill that ran afterwards could not
+         * observe a copy that moved the wrong number of bytes. The fill spans
+         * the usable size rather than the request, so it doubles as the check
+         * on tlsf_usable_size(): under-reporting trips the assert,
+         * over-reporting corrupts a neighbour that tlsf_check() sees.
+         */
+        uint8_t *data = (uint8_t *) p[i];
+        uint8_t tag = (uint8_t) i;
+        size_t usable = tlsf_usable_size(data);
+        assert(usable >= len);
+        memset(data, tag, usable);
+
         if (TEST_RAND() % 10 == 0) {
+            size_t old_len = len;
             len = ((size_t) TEST_RAND() % cap) + 1;
             p[i] = tlsf_realloc(t, p[i], len);
             assert(p[i]);
+            data = (uint8_t *) p[i];
+            usable = tlsf_usable_size(data);
+            assert(usable >= len);
+
+            /* Only the smaller of the two requests is promised to survive, so
+             * that is what gets checked. This allocator carries the whole block
+             * across, having no record of the request to copy less by, but
+             * pinning that would fail a realloc that legitimately copied only
+             * what it owes. Nothing is lost by asking for less: a half-length
+             * and a one-word-short copy are both caught on 20 of 20 runs either
+             * way, because a request often lands within an alignment unit of
+             * the block it got.
+             *
+             * Comparing the run against itself shifted by one byte is the cheap
+             * way to assert every byte holds 'tag': it reaches libc's
+             * vectorised memcmp, where a per-byte loop with an assert in it
+             * cannot be vectorised and tripled the suite's runtime.
+             */
+            size_t keep = old_len < len ? old_len : len;
+            assert(data[0] == tag && !memcmp(data, data + 1, keep - 1));
+
+            /* Growth exposes bytes realloc never wrote. Tag them so the
+             * free-time sweep can cover the whole extent.
+             */
+            memset(data + keep, tag, usable - keep);
         }
 
         if (i % check_stride == 0)
             tlsf_check(t);
-
-        /* Fill with magic (only when testing up to 1MB). The fill runs over the
-         * usable size rather than the requested length, so it doubles as the
-         * check on tlsf_usable_size(): under-reporting trips the assert, and
-         * over-reporting corrupts a neighbour that tlsf_check() then sees.
-         */
-        uint8_t *data = (uint8_t *) p[i];
-        size_t usable = tlsf_usable_size(data);
-        assert(usable >= len);
-        if (spacelen <= 1024 * 1024)
-            memset(data, 0, usable);
-        data[0] = 0xa5;
 
         i++;
     }
@@ -263,8 +290,15 @@ static void random_test(tlsf_t *t, size_t spacelen, const size_t cap)
         if (p[target] == NULL)
             continue;
 
+        /* Sweep the whole extent, which reaches the successor's 'prev' field:
+         * that word overlays the last payload word of a used block, and only an
+         * operation on this very block may write it. A block_link_next() added
+         * to block_rtrim_used(), say, would break that and trip here.
+         */
         uint8_t *data = (uint8_t *) p[target];
-        assert(data[0] == 0xa5);
+        uint8_t tag = (uint8_t) target;
+        size_t usable = tlsf_usable_size(data);
+        assert(data[0] == tag && !memcmp(data, data + 1, usable - 1));
         tlsf_free(t, p[target]);
         p[target] = NULL;
         n--;

--- a/tests/test.c
+++ b/tests/test.c
@@ -1330,10 +1330,10 @@ static void trim_boundary_test(void)
         return;
     }
 
-    /* An unaligned split threshold is legal and the library is right under
-     * one: block sizes and adjusted requests are both alignment multiples, so
-     * their difference is too and never equals an unaligned min_total. The
-     * boundary is unreachable, not broken, so skip rather than fail.
+    /* An unaligned split threshold is legal and the library is right under one:
+     * block sizes and adjusted requests are both alignment multiples, so their
+     * difference is too and never equals an unaligned min_total. The boundary
+     * is unreachable, not broken, so skip rather than fail.
      */
     if (remainder % sizeof(size_t)) {
         printf(
@@ -1482,8 +1482,8 @@ static void pool_ceiling_test(void)
            align);
 }
 
-/* The claim the whole largest_free change rests on: the reported figure names
- * a size malloc() will serve, not merely a block that exists.
+/* The claim the whole largest_free change rests on: the reported figure names a
+ * size malloc() will serve, not merely a block that exists.
  */
 static void assert_largest_free_allocatable(tlsf_t *t, size_t largest)
 {
@@ -1596,8 +1596,8 @@ static void oversized_free_block_test(void)
     assert(tlsf_get_stats(&t, &stats) == 0);
     assert(stats.free_count == 1);
 
-    /* free_count is 1, so total_free is that block. largest_free is clamped
-     * and cannot show that it exceeds any single allocation.
+    /* free_count is 1, so total_free is that block. largest_free is clamped and
+     * cannot show that it exceeds any single allocation.
      */
     assert(stats.total_free > TLSF_MAX_SIZE);
     assert(stats.total_free < ceiling);
@@ -1621,11 +1621,11 @@ static void largest_free_rounding_test(void)
     printf("Largest-free rounding test: ");
     fflush(stdout);
 
-    /* The pool must already be ALIGN_SIZE-aligned. pool_init() would
-     * otherwise skip up to ALIGN_SIZE-1 bytes to align it and the expected
-     * figure below would move. A size_t array gives exactly that alignment;
-     * max_align_t would too, but MSVC does not declare it in C mode. 1056 is
-     * a multiple of sizeof(size_t) at both widths, so the span is exact.
+    /* The pool must already be ALIGN_SIZE-aligned. pool_init() would otherwise
+     * skip up to ALIGN_SIZE-1 bytes to align it and the expected figure below
+     * would move. A size_t array gives exactly that alignment; max_align_t
+     * would too, but MSVC does not declare it in C mode. 1056 is a multiple of
+     * sizeof(size_t) at both widths, so the span is exact.
      */
     size_t pool[1056 / sizeof(size_t)];
     tlsf_t t;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hardens the test suite so a green run proves the behavior each test names, not just that something aborted.

- Expands `check_negative` from 4 to 22 cases, pairing each corruption with the exact CHECK diagnostic it must produce; the runner fetches the expected message via a new `-e` flag and fails on any mismatch instead of accepting any `TLSF CHECK:` line.
- Adds a mirror of `src/tlsf.c`'s block encoding in `tests/check_negative.c`, self-checked against a live pool before each run, so a case flips the bit it names.
- `random_test` now tags each allocation with a per-index byte and verifies the whole usable extent across realloc, so a copy that moves the wrong number of bytes fails instead of passing on one untouched magic byte.
- Reflows comments in both test files; no behavior change.

<sup>Written for commit e6c5443b7d85208134b30abdd04c3a14f8d0e807. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/tlsf-bsd/pull/45?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

