### PR TITLE
Make align C11 and higher appliable

### DIFF
--- a/include/tlsf_thread.h
+++ b/include/tlsf_thread.h
@@ -215,12 +215,12 @@
     !defined(__cplusplus)
 #define TLSF_MSVC_ALIGN(x)
 #define TLSF_GCC_ALIGN(x)
-#define TLSF_C11C23_ALIGN(x) _Alignas(x)
+#define TLSF_C11C23_ALIGN(x) alignas(x)
 #elif (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L) && \
     !defined(__cplusplus)
 #define TLSF_MSVC_ALIGN(x)
 #define TLSF_GCC_ALIGN(x)
-#define TLSF_C11C23_ALIGN(x) alignas(x)
+#define TLSF_C11C23_ALIGN(x) _Alignas(x)
 #else
 #define TLSF_MSVC_ALIGN(x)
 #define TLSF_GCC_ALIGN(x)

--- a/include/tlsf_thread.h
+++ b/include/tlsf_thread.h
@@ -195,15 +195,36 @@
 
 #endif /* TLSF_LOCK_T */
 
-#if defined(_MSC_VER)
+/* Define here TLSF_NO_COMPATIBLE_ALIGN
+ * if compiler is GCC/Clang or some other with randomize layout
+ * but randomize_layout and strict mode are set on simultaneously.
+ */
+#if defined(TLSF_NO_COMPATIBLE_ALIGN)
+#define TLSF_MSVC_ALIGN(x)
+#define TLSF_GCC_ALIGN(x)
+#define TLSF_C11C23_ALIGN(x)
+#elif defined(_MSC_VER)
 #define TLSF_MSVC_ALIGN(x) __declspec(align(x))
 #define TLSF_GCC_ALIGN(x)
+#define TLSF_C11C23_ALIGN(x)
 #elif defined(__GNUC__) || defined(__clang__)
 #define TLSF_MSVC_ALIGN(x)
 #define TLSF_GCC_ALIGN(x) __attribute__((aligned(x)))
+#define TLSF_C11C23_ALIGN(x)
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L && \
+    !defined(__cplusplus)
+#define TLSF_MSVC_ALIGN(x)
+#define TLSF_GCC_ALIGN(x)
+#define TLSF_C11C23_ALIGN(x) _Alignas(x)
+#elif (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L) && \
+    !defined(__cplusplus)
+#define TLSF_MSVC_ALIGN(x)
+#define TLSF_GCC_ALIGN(x)
+#define TLSF_C11C23_ALIGN(x) alignas(x)
 #else
 #define TLSF_MSVC_ALIGN(x)
 #define TLSF_GCC_ALIGN(x)
+#define TLSF_C11C23_ALIGN(x)
 #endif
 
 /* Define here optional TLSF_THREAD_HINT()
@@ -341,7 +362,7 @@ extern "C" {
 #endif
 
 TLSF_MSVC_ALIGN(TLSF_CACHELINE_SIZE) typedef struct {
-    tlsf_t pool;
+    TLSF_C11C23_ALIGN(TLSF_CACHELINE_SIZE) tlsf_t pool;
     TLSF_LOCK_T lock;
 
     /* Raw chunk handed to this arena. Ownership lookup tests against this

--- a/include/tlsf_thread.h
+++ b/include/tlsf_thread.h
@@ -195,15 +195,7 @@
 
 #endif /* TLSF_LOCK_T */
 
-/* Define here TLSF_NO_COMPATIBLE_ALIGN
- * if compiler is GCC/Clang or some other with randomize layout
- * but randomize_layout and strict mode are set on simultaneously.
- */
-#if defined(TLSF_NO_COMPATIBLE_ALIGN)
-#define TLSF_MSVC_ALIGN(x)
-#define TLSF_GCC_ALIGN(x)
-#define TLSF_C11C23_ALIGN(x)
-#elif defined(_MSC_VER)
+#if defined(_MSC_VER)
 #define TLSF_MSVC_ALIGN(x) __declspec(align(x))
 #define TLSF_GCC_ALIGN(x)
 #define TLSF_C11C23_ALIGN(x)

--- a/tests/test_thread.c
+++ b/tests/test_thread.c
@@ -490,8 +490,8 @@ static void init_limits_test(void)
      * and init unwinds.
      */
     TLSF_MSVC_ALIGN(16)
-    TLSF_C11C23_ALIGN(
-        16) static char cramped[TLSF_TEST_BLOCK_COST] TLSF_GCC_ALIGN(16);
+    TLSF_C11C23_ALIGN(16)
+    static char cramped[TLSF_TEST_BLOCK_COST] TLSF_GCC_ALIGN(16);
     assert(tlsf_thread_init(&small, cramped, sizeof(cramped)) == 0);
     assert(small.count == 0);
 

--- a/tests/test_thread.c
+++ b/tests/test_thread.c
@@ -40,7 +40,8 @@
 #define MAX_ALLOCS 128
 #define MAX_ALLOC_SIZE 2048
 
-TLSF_MSVC_ALIGN(16) static char pool[POOL_SIZE] TLSF_GCC_ALIGN(16);
+TLSF_MSVC_ALIGN(16)
+TLSF_C11C23_ALIGN(16) static char pool[POOL_SIZE] TLSF_GCC_ALIGN(16);
 static tlsf_thread_t ts;
 
 #if defined(_TLSF_USE_C11_THREADS)
@@ -489,7 +490,8 @@ static void init_limits_test(void)
      * and init unwinds.
      */
     TLSF_MSVC_ALIGN(16)
-    static char cramped[TLSF_TEST_BLOCK_COST] TLSF_GCC_ALIGN(16);
+    TLSF_C11C23_ALIGN(
+        16) static char cramped[TLSF_TEST_BLOCK_COST] TLSF_GCC_ALIGN(16);
     assert(tlsf_thread_init(&small, cramped, sizeof(cramped)) == 0);
     assert(small.count == 0);
 
@@ -504,7 +506,8 @@ static void init_limits_test(void)
      * per-arena minimum that tlsf_thread_init() enforces, so the count has to
      * halve at least once.
      */
-    TLSF_MSVC_ALIGN(16) static char narrow[2 * 256] TLSF_GCC_ALIGN(16);
+    TLSF_MSVC_ALIGN(16)
+    TLSF_C11C23_ALIGN(16) static char narrow[2 * 256] TLSF_GCC_ALIGN(16);
     size_t usable = tlsf_thread_init(&small, narrow, sizeof(narrow));
     assert(usable > 0);
     assert(small.count >= 1);


### PR DESCRIPTION
Macros TLSF_MSVC_ALIGN(x) and TLSF_GCC_ALIGN(x) can align only for GCC/Clang/MSVC compilers.
This PR adds support for other compilers that support C11 or higher.
The main problem that keywords _Alignas from C11 and alignas from C23 can't be applied to overall structure.
But cause sequence order of struct fields according to the standard is remains unchanged during compilation
aligning first field is the same as aligning all structure.
But main problem in that GCC and Clang have randomize_layout mode. In this mode they shuffle struct fields randomly.
There is no way to detect this mode by preprocessor. And if user sets on randomize_layot and strict mode simultaneously
aligning will break. For this purpose this PR adds TLSF_NO_COMPATIBLE_ALIGN macro for setting off aligning. 
 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds C11/C23 alignment support for compilers without GCC/Clang/MSVC syntax. The new `TLSF_C11C23_ALIGN` macro uses `_Alignas`/`alignas` and is applied to the first field of the arena struct — which aligns the whole struct since field order is preserved — plus the thread test buffers. The previously proposed `TLSF_NO_COMPATIBLE_ALIGN` opt-out was removed as unnecessary.

<sup>Written for commit b2eabdb2d88155eeed777f14d235edad123187bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/tlsf-bsd/pull/46?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

