### PR TITLE
Add std::pmr adapters for both allocators

### DIFF
--- a/.ci/check-abi-guard.sh
+++ b/.ci/check-abi-guard.sh
@@ -12,6 +12,7 @@ set -e -u -o pipefail
 
 CC="${CC:-cc}"
 CFLAGS_COMMON="-Iinclude -std=gnu11 -O1 -pthread"
+CXXFLAGS_COMMON="-Iinclude -std=c++17 -pthread"
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 
@@ -108,9 +109,9 @@ check fails "-DTLSF_CACHELINE_SIZE=128" thread "thread: TLSF_CACHELINE_SIZE mism
 check fails "-DTLSF_MAX_POOL_BITS=20" thread "thread: TLSF_MAX_POOL_BITS mismatch"
 
 # TLSF_C11_THREADS does not decide the lock backend on its own. The header
-# selects on _TLSF_USE_C11_THREADS, which also needs the compiler to have a usable
-# '<threads.h>', so whether the flag changes anything is a property of the host.
-# Ask the header which backend it picked rather than inferring it.
+# selects on _TLSF_USE_C11_THREADS, which also needs the compiler to have a
+# usable '<threads.h>', so whether the flag changes anything is a property of
+# the host. Ask the header which backend it picked rather than inferring it.
 #
 # Do not infer it from sizeof either. On glibc, mtx_t and pthread_mutex_t are
 # the same size, so the wrapper measures identical while the lock operations
@@ -176,8 +177,8 @@ EOF
 # Swallowing the preprocessor's exit status, not its diagnostics: those still
 # reach the job log. A directive the header rejects under these defines would
 # otherwise take 'set -e' out through the command substitution below, ending the
-# script on a bare status with none of the checks reported. A failure here has to
-# print its FAIL line like every other check, which is what the empty-value
+# script on a bare status with none of the checks reported. A failure here has
+# to print its FAIL line like every other check, which is what the empty-value
 # default below is for.
 win_symbol() {
 	# shellcheck disable=SC2086
@@ -203,6 +204,154 @@ else
 	echo "FAIL: thread: Windows lock backends share a symbol name" \
 		"($srwlock vs $crsection)"
 	ret=1
+fi
+
+# The C++ adapters in include/tlsf_pmr.hpp and include/tlsf_thread_pmr.hpp would
+# be a hole in everything above if their classes were left untagged. A
+# header-defined class has weak definitions for its vtable and its inline
+# virtuals, and those mangled names carry no configuration, so two mismatched
+# units emit the same 'do_allocate' twice. A linker that keeps one COMDAT group
+# and discards the other discards the discarded copy's reference to the suffixed
+# C symbol with it, and the undefined reference that should have failed the link
+# is gone. The classes sit in inline namespaces named by the same suffix so that
+# cannot happen.
+#
+# Names, not link behavior, for the reason the Windows arm above gives: whether
+# a mismatch reaches the linker is a property of the object format. Mach-O keeps
+# the reference and rejects the link with or without the tagging, so a link test
+# would pass there while proving nothing. The mangled name differs on every
+# host.
+CXX="${CXX:-c++}"
+
+cat >"$tmp/pmr.cpp" <<'EOF'
+#include "tlsf_pmr.hpp"
+#include "tlsf_thread_pmr.hpp"
+static tlsf_t core;
+static tlsf_thread_t threaded;
+tlsf::pmr_resource core_res(core);
+tlsf::pmr_thread_resource thread_res(threaded);
+EOF
+
+# Print the last probe's compiler output, indented, if there is any. The file is
+# absent when the probe never ran, and a redirection from a missing file is a
+# shell error that no redirection on the reader can silence.
+pmr_log() {
+	[ -f "$tmp/pmr.log" ] && sed 's/^/    /' <"$tmp/pmr.log"
+	return 0
+}
+
+# $1 selects the class, $2 and up are the caller's configuration flags.
+#
+# The object is named after the flags and reused. Every pmr_check needs the
+# unflagged baseline, so compiling on each call rebuilt an unchanged file once
+# per check, and the same variant is asked for by two different checks.
+#
+# Keyed on a checksum, not on the flags with punctuation folded away: that
+# folding maps '-DX=8' and '-DX 8' to one name, and reusing the wrong object
+# here would answer "same" to a check whose whole purpose is noticing when two
+# configurations differ.
+pmr_symbol() {
+	which="$1"
+	shift
+	obj="$tmp/pmr$(printf '%s' "$*" | cksum | tr -cd '0-9').o"
+	if [ ! -f "$obj" ]; then
+		# shellcheck disable=SC2086
+		$CXX $CXXFLAGS_COMMON -O0 "$@" -c -o "$obj" \
+			"$tmp/pmr.cpp" >"$tmp/pmr.log" 2>&1 || return 1
+	fi
+	case "$which" in
+	core) nm "$obj" | grep do_allocate | grep pmr_resource |
+		grep -v pmr_thread_resource ;;
+	thread) nm "$obj" | grep do_allocate | grep pmr_thread_resource ;;
+	esac | awk '{print $NF}' | head -1
+}
+
+# pmr_compiles <flag> -- the adapters must still build under <flag>.
+pmr_compiles() {
+	# shellcheck disable=SC2086
+	if $CXX $CXXFLAGS_COMMON "$1" -fsyntax-only "$tmp/pmr.cpp" \
+		>"$tmp/pmr.log" 2>&1; then
+		echo "ok: pmr: adapters compile with $1"
+	else
+		echo "FAIL: pmr: adapters no longer compile with $1"
+		pmr_log
+		ret=1
+	fi
+}
+
+# same <core|thread> <expected same|differ> <description> <flags...>
+pmr_check() {
+	which="$1"
+	expect="$2"
+	desc="$3"
+	shift 3
+	base="$(pmr_symbol "$which" || true)"
+	other="$(pmr_symbol "$which" "$@" || true)"
+	if [ -z "$base" ] || [ -z "$other" ]; then
+		echo "FAIL: $desc: no do_allocate symbol found"
+		pmr_log
+		ret=1
+		return
+	fi
+	if [ "$base" = "$other" ]; then
+		got=same
+	else
+		got=differ
+	fi
+	if [ "$got" != "$expect" ]; then
+		echo "FAIL: $desc: expected $expect, got $got ($base vs $other)"
+		ret=1
+		return
+	fi
+	echo "ok: $desc ($got)"
+}
+
+# Two probes, not one. The first asks whether this toolchain has what the
+# adapters need, C++17 '<memory_resource>', and a no there is a skip. Only then
+# is a failure to compile the adapters themselves the regression this section
+# exists to catch. Deciding both from a single compile of pmr.cpp would report a
+# header that stopped compiling as a note and exit 0, which is the guard passing
+# while testing nothing.
+cat >"$tmp/pmr_probe.cpp" <<'EOF'
+#include <memory_resource>
+std::pmr::memory_resource *probe = std::pmr::new_delete_resource();
+EOF
+
+# No 'command -v' guard on $CXX: it cannot answer for a value carrying flags,
+# which is an ordinary way to pass them, and a no there skipped everything below
+# without a word. Let the compile decide, and print why.
+# shellcheck disable=SC2086
+if ! $CXX -std=c++17 -fsyntax-only "$tmp/pmr_probe.cpp" \
+	>"$tmp/pmr.log" 2>&1; then
+	echo "note: skipping pmr checks: $CXX has no usable" \
+		"C++17 '<memory_resource>'"
+	pmr_log
+elif ! $CXX $CXXFLAGS_COMMON -fsyntax-only "$tmp/pmr.cpp" \
+	>"$tmp/pmr.log" 2>&1; then
+	echo "FAIL: pmr: $CXX has what the adapters need" \
+		"but cannot compile them"
+	pmr_log
+	ret=1
+else
+	# -fno-exceptions is ordinary in embedded C++, and do_is_equal() promises
+	# in its comment that it declines to compare pools so the headers stay
+	# usable under -fno-rtti. Both are claims about where these headers can be
+	# built, and the change most likely to break either is the one a reviewer
+	# will propose, so each gets a check rather than a comment.
+	pmr_compiles -fno-exceptions
+	pmr_compiles -fno-rtti
+
+	pmr_check core differ "pmr: TLSF_MAX_POOL_BITS reaches pmr_resource" \
+		-DTLSF_MAX_POOL_BITS=20
+	pmr_check thread differ \
+		"pmr: TLSF_ARENA_COUNT reaches pmr_thread_resource" \
+		-DTLSF_ARENA_COUNT=8
+
+	# The two classes are tagged separately on purpose. Folding them into one
+	# namespace would reject a pair of units differing only in a knob that does
+	# not move 'tlsf_t', which is a working build turned into a link error.
+	pmr_check core same "pmr: a thread knob leaves pmr_resource alone" \
+		-DTLSF_ARENA_COUNT=8
 fi
 
 exit $ret

--- a/.ci/check-format.sh
+++ b/.ci/check-format.sh
@@ -16,7 +16,7 @@ PY_FORMAT_EXIT=0
 C_SOURCES=()
 while IFS= read -r file; do
 	[ -n "$file" ] && C_SOURCES+=("$file")
-done < <(git ls-files -- 'include/*.h' 'src/*.c' 'src/*.h' 'ports/*.c' 'ports/*.h' 'tests/*.c' 'tests/*.h' 'tests/*.cpp')
+done < <(git ls-files -- 'include/*.h' 'include/*.hpp' 'src/*.c' 'src/*.h' 'ports/*.c' 'ports/*.h' 'tests/*.c' 'tests/*.h' 'tests/*.cpp')
 
 if [ ${#C_SOURCES[@]} -gt 0 ]; then
 	if command -v clang-format-20 >/dev/null 2>&1; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,13 @@ jobs:
       # expands them, and .ci/check-abi-guard.sh proves the result links, so
       # the finding says something about cppcheck rather than about the header.
       #
+      # The fourth is the same emulation failing on get_thread_hint(). Where a
+      # caller supplies TLSF_THREAD_HINT(), cppcheck has no definition to expand
+      # and reports the call as a syntax error. The cppcheck this job installs
+      # is several minor versions behind current and does not report it yet; a
+      # newer one does, so the suppression is here before a runner image bump
+      # turns a tool limitation into a red build on untouched code.
+      #
       # The suppressions are flags rather than a suppression file: the file
       # format is not portable across cppcheck versions, and the one in Ubuntu
       # 24.04 rejects the comments that made the file worth having.
@@ -64,6 +71,7 @@ jobs:
             --suppress=knownConditionTrueFalse:src/tlsf.c \
             --suppress=preprocessorErrorDirective:include/tlsf.h \
             --suppress=preprocessorErrorDirective:include/tlsf_thread.h \
+            --suppress=syntaxError:src/tlsf_thread.c \
             --error-exitcode=1 --quiet src include
 
   # Nothing measured how much of the allocator the suite reached until this

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,9 @@ jobs:
             cc: clang
             cflags: "-fsanitize=address,undefined"
           - runner: ubuntu-24.04
+            cc: gcc
+            cxxflags: "-fno-exceptions"
+          - runner: ubuntu-24.04
             cc: clang
             cflags: "-fsanitize=address,undefined -DTLSF_ENABLE_POISON"
           - runner: ubuntu-24.04-arm
@@ -200,12 +203,14 @@ jobs:
         env:
           CC: ${{ matrix.cc }}
           CXX: ${{ matrix.cc == 'clang' && 'clang++' || 'g++' }}
+          CXXFLAGS: ${{ matrix.cxxflags }}
           CPPFLAGS: ${{ matrix.cflags }}
       - name: Test
         run: make check ${{ matrix.make_args }}
         env:
           CC: ${{ matrix.cc }}
           CXX: ${{ matrix.cc == 'clang' && 'clang++' || 'g++' }}
+          CXXFLAGS: ${{ matrix.cxxflags }}
           CPPFLAGS: ${{ matrix.cflags }}
   
   # 32-bit build: exercises the _TLSF_SIZE_WIDTH == 32 paths (ALIGN_SHIFT 2,
@@ -325,6 +330,24 @@ jobs:
       - name: Run Multi-Threaded Tests (native lock)
         run: |
           .\test_thread_native.exe
+      # The only place the std::pmr adapters meet MSVC, and the reason their
+      # language gate reads '_MSVC_LANG': cl leaves '__cplusplus' at 199711L
+      # unless '/Zc:__cplusplus' is passed, and '/std:c++17' does not imply it,
+      # so a gate on '__cplusplus' alone rejects this exact command line. That
+      # flag is deliberately absent here. Everything else in this job compiles
+      # C++ at /std:c++14, which the adapters correctly refuse.
+      #
+      # '/EHsc' because do_allocate throws on exhaustion; without it cl warns
+      # C4530 and the throw is not the one the test is checking for. Links the
+      # native-lock 'tlsf_thread.obj' left by the step above, so the C and C++
+      # units agree on the backend and the token paste, the same pairing the
+      # /std:c++14 steps test.
+      - name: Compile C++17 PMR Test with MSVC
+        run: |
+          cl.exe /Iinclude /O2 /W3 /we4146 /we4334 /std:c++17 /EHsc /DTLSF_ENABLE_ASSERT /DTLSF_ENABLE_CHECK tests\test_pmr.cpp tlsf.obj tlsf_thread.obj /Fe:test_pmr.exe
+      - name: Run C++17 PMR Test
+        run: |
+          .\test_pmr.exe
       - name: Compile Benchmark TLSF with MSVC
         run: |
           cl.exe /Iinclude /O2 /W3 /we4146 /we4334 /std:c11 /DTLSF_ENABLE_ASSERT /DTLSF_ENABLE_CHECK tests\bench.c tlsf.obj /Fe:bench_tlsf.exe /link Psapi.lib

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 OUT = build
 
+.DEFAULT_GOAL := all
+
 FRAMAC ?= frama-c
 
 # Leaf helpers carrying ACSL contracts. No caller of these is in the list yet,
@@ -42,7 +44,11 @@ TARGETS := $(addprefix $(OUT)/,$(TARGETS))
 THREAD_TARGETS = $(OUT)/test_thread
 CPP_TARGETS = $(OUT)/test_cpp
 
-all: $(TARGETS) $(THREAD_TARGETS) $(CPP_TARGETS)
+# Named outside the probe below so 'clean' can remove it either way. A tree
+# built with a C++17 toolchain and cleaned with an older one would otherwise
+# keep a stale binary and its dep file, which is the same trap the 'deps'
+# comment further down guards against.
+PMR_TARGET = $(OUT)/test_pmr
 
 # Full benchmark with statistical rigor (50 iterations, 5 warmup)
 bench: all
@@ -70,17 +76,44 @@ override CPPFLAGS += -Iinclude $(TLSF_DEBUG_FLAGS)
 TLSF_WARNINGS = \
   -Wall -Wextra -Wshadow -Wpointer-arith -Wcast-qual -Wconversion
 
-CFLAGS += \
+override CFLAGS += \
   -std=gnu11 -g -O2 \
   $(TLSF_WARNINGS) -Wc++-compat
 
-CXXFLAGS += \
+override CXXFLAGS += \
   -std=c++11 -g -O2 \
   $(TLSF_WARNINGS) -pedantic-errors
 
+# The public headers stay compilable as C++11 while the adapters need C++17.
+# Appending a second -std rather than editing CXXFLAGS keeps that split: the
+# later flag wins, so tests/test_cpp.cpp still proves the C++11 baseline and
+# only this one target is raised. A caller's own '-std' is overridden here, as
+# it already is for test_cpp, because 'override CXXFLAGS +=' appends to the
+# caller's value rather than replacing it, leaving that value first on the
+# command line. Plain '+=' would append only to an environment value and be
+# skipped outright for a command-line one, so a command-line CXXFLAGS would
+# build test_cpp with no -std at all and pin nothing.
+CXX17FLAGS = $(CXXFLAGS) -std=c++17
+
+# The std::pmr adapters are optional, so their probe uses the same
+# preprocessor and C++ flags as their target before adding it to 'check'.
+#
+# No exceptions are needed to use the adapters: a failed allocation terminates
+# when they are disabled, because memory_resource cannot report a null result.
+PMR_PROBE := $(shell printf \
+	'\043include <memory_resource>\nint main(){}\n' \
+	| $(CXX) $(CPPFLAGS) $(CXX17FLAGS) -pthread -fsyntax-only \
+		-x c++ - 2>/dev/null && echo yes)
+ifeq ($(PMR_PROBE),yes)
+CPP_TARGETS += $(PMR_TARGET)
+endif
+
+all: $(TARGETS) $(THREAD_TARGETS) $(CPP_TARGETS)
+
 # The header's own knobs are spelled '_TLSF_' as well as 'TLSF_', and either
 # prefix can arrive as -U rather than -D, so all four forms have to be caught.
-ifneq ($(filter -DTLSF_% -D_TLSF_% -UTLSF_% -U_TLSF_%,$(CFLAGS) $(CXXFLAGS)),)
+ifneq ($(filter -DTLSF_% -D_TLSF_% -UTLSF_% -U_TLSF_%, \
+	$(CFLAGS) $(CXXFLAGS) $(CXX17FLAGS)),)
 $(error Pass TLSF configuration macros through CPPFLAGS, not CFLAGS or CXXFLAGS)
 endif
 
@@ -93,7 +126,7 @@ THREAD_OBJS = $(OUT)/tlsf_thread.o
 # file behind. $(OUT)/test is deliberately absent: its rule emits no dep file.
 deps := $(OBJS:%.o=%.o.d) $(THREAD_OBJS:%.o=%.o.d) \
 	$(OUT)/bench.d $(OUT)/wcet.d $(OUT)/fuzz.d $(OUT)/check_negative.d \
-	$(THREAD_TARGETS:%=%.d) $(CPP_TARGETS:%=%.d)
+	$(THREAD_TARGETS:%=%.d) $(CPP_TARGETS:%=%.d) $(PMR_TARGET:%=%.d)
 
 # Make compares timestamps, not command lines, so flipping a variable on the
 # command line rebuilds nothing. 'make check TLSF_DEBUG_FLAGS=' on an
@@ -107,7 +140,8 @@ deps := $(OBJS:%.o=%.o.d) $(THREAD_OBJS:%.o=%.o.d) \
 # LDFLAGS-only change also recompiles the two objects. Rebuilding more than
 # strictly needed is safe, and a second stamp is not worth the machinery here.
 FLAGS_STAMP := $(OUT)/.build-flags
-BUILD_FLAGS := $(CC) $(CXX) $(CPPFLAGS) $(CFLAGS) $(CXXFLAGS) $(LDFLAGS)
+BUILD_FLAGS := $(CC) $(CXX) $(CPPFLAGS) $(CFLAGS) $(CXXFLAGS) $(CXX17FLAGS) \
+	$(LDFLAGS)
 
 # Exported rather than pasted into the recipe text. A flag value may contain a
 # quote, and interpolating one into a quoted shell word would end the string
@@ -160,19 +194,34 @@ $(OUT)/test_cpp: $(OBJS) $(THREAD_OBJS) tests/test_cpp.cpp $(FLAGS_STAMP)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -pthread -o $@ -MMD -MF $@.d $(OBJS) \
 		$(THREAD_OBJS) tests/test_cpp.cpp $(LDFLAGS)
 
+$(PMR_TARGET): $(OBJS) $(THREAD_OBJS) tests/test_pmr.cpp $(FLAGS_STAMP)
+	$(CXX) $(CPPFLAGS) $(CXX17FLAGS) -pthread -o $@ -MMD -MF $@.d $(OBJS) \
+		$(THREAD_OBJS) tests/test_pmr.cpp $(LDFLAGS)
+
 $(OUT)/%.o: src/%.c $(FLAGS_STAMP)
 	@mkdir -p $(OUT)
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c -o $@ -MMD -MF $@.d $<
 
+# Every runner below names $(OUT) rather than a literal 'build'. With the
+# literal, 'make OUT=elsewhere check' built into one directory and ran whatever
+# an earlier build had left in the other, reporting a pass for binaries it had
+# not produced; with no 'build' at all it failed on the first line. The path
+# carries a slash either way, so no './' prefix is needed, and dropping it is
+# also what lets an absolute $(OUT) work.
 check: $(TARGETS) $(THREAD_TARGETS) $(CPP_TARGETS) check-negative
-	MALLOC_CHECK_=3 ./build/test
-	MALLOC_CHECK_=3 ./build/bench -l 10000 -i 3 -w 1
-	MALLOC_CHECK_=3 ./build/bench -s 32 -l 10000 -i 3 -w 1
-	MALLOC_CHECK_=3 ./build/bench -s 10:12345 -l 10000 -i 3 -w 1
-	./build/wcet -i 100 -w 10
-	MALLOC_CHECK_=3 ./build/fuzz
-	./build/test_thread
-	./build/test_cpp
+	MALLOC_CHECK_=3 $(OUT)/test
+	MALLOC_CHECK_=3 $(OUT)/bench -l 10000 -i 3 -w 1
+	MALLOC_CHECK_=3 $(OUT)/bench -s 32 -l 10000 -i 3 -w 1
+	MALLOC_CHECK_=3 $(OUT)/bench -s 10:12345 -l 10000 -i 3 -w 1
+	$(OUT)/wcet -i 100 -w 10
+	MALLOC_CHECK_=3 $(OUT)/fuzz
+	$(OUT)/test_thread
+	$(OUT)/test_cpp
+ifeq ($(PMR_PROBE),yes)
+	$(PMR_TARGET)
+else
+	@echo "test_pmr: skipped ($(CXX) lacks C++17 <memory_resource>)"
+endif
 
 # Each case must abort with the CHECK diagnostic it names, not with a segfault
 # that looks like one and not with some other check that happens to fire first.
@@ -192,22 +241,22 @@ check: $(TARGETS) $(THREAD_TARGETS) $(CPP_TARGETS) check-negative
 # then rejects. Cores are off because the aborts are expected.
 check-negative: $(OUT)/check_negative
 	@ulimit -c 0; \
-	./$(OUT)/check_negative; n=$$?; \
+	$(OUT)/check_negative; n=$$?; \
 	if [ "$$n" -eq 0 ]; then \
 		echo "check_negative: skipped (built without TLSF_ENABLE_CHECK)"; \
 		exit 0; \
 	fi; \
-	if ! ./$(OUT)/check_negative -1 >/dev/null 2>&1; then \
+	if ! $(OUT)/check_negative -1 >/dev/null 2>&1; then \
 		echo "check_negative: control case failed; harness is broken" >&2; \
 		exit 1; \
 	fi; \
 	i=0; \
 	while [ "$$i" -lt "$$n" ]; do \
-		if ! want=$$(./$(OUT)/check_negative -e $$i 2>&1); then \
+		if ! want=$$($(OUT)/check_negative -e $$i 2>&1); then \
 			echo "check_negative: case $$i has no expected message:" >&2; \
 			echo "$$want" >&2; exit 1; \
 		fi; \
-		if out=$$(./$(OUT)/check_negative $$i 2>&1); then \
+		if out=$$($(OUT)/check_negative $$i 2>&1); then \
 			echo "check_negative: case $$i accepted by tlsf_check()" >&2; \
 			exit 1; \
 		fi; \
@@ -265,20 +314,20 @@ fuzz: $(FLAGS_STAMP)
 
 # Full WCET measurement (10000 iterations, 1000 warmup)
 wcet: all
-	./build/wcet
+	$(OUT)/wcet
 
 # Quick WCET check for development
 wcet-quick: all
-	./build/wcet -i 1000 -w 100
+	$(OUT)/wcet -i 1000 -w 100
 
 # WCET with raw output and analysis plots
 wcet-plot: all
 	@mkdir -p $(OUT)
-	./build/wcet -i 10000 -r $(OUT)/wcet_raw.csv -c > $(OUT)/wcet_summary.csv
+	$(OUT)/wcet -i 10000 -r $(OUT)/wcet_raw.csv -c > $(OUT)/wcet_summary.csv
 	python3 scripts/wcet_plot.py $(OUT)/wcet_raw.csv -o $(OUT)/wcet
 
 clean:
-	$(RM) $(TARGETS) $(THREAD_TARGETS) $(CPP_TARGETS)
+	$(RM) $(TARGETS) $(THREAD_TARGETS) $(CPP_TARGETS) $(PMR_TARGET)
 	$(RM) $(OBJS) $(THREAD_OBJS) $(deps) $(FLAGS_STAMP)
 	$(RM) $(OUT)/wcet_raw.csv $(OUT)/wcet_summary.csv
 	$(RM) $(OUT)/wcet_boxplot.png $(OUT)/wcet_histogram.png

--- a/README.md
+++ b/README.md
@@ -187,6 +187,74 @@ The full knob list is in
 [Thread wrapper flags](docs/configuration-and-verification.md#thread-wrapper-flags),
 and the design is in [Concurrency](docs/operations.md#concurrency).
 
+### C++ std::pmr adapters
+
+`include/tlsf_pmr.hpp` is an optional, header-only C++17 wrapper for consumers
+that accept a `std::pmr::memory_resource`, such as ROS 2 nodes. Including it
+requires C++17; the library and its public headers stay C11 and C++11.
+
+```cpp
+#include <vector>
+
+#include "tlsf_pmr.hpp"
+
+alignas(64) static unsigned char memory[64 * 1024];
+
+tlsf_t pool = TLSF_INIT;
+if (!tlsf_pool_init(&pool, memory, sizeof(memory)))
+    return -1;
+
+tlsf::pmr_resource res(pool);
+std::pmr::vector<int> v(&res);
+v.push_back(1);
+```
+
+`tlsf::pmr_thread_resource`, in the separate `include/tlsf_thread_pmr.hpp`,
+is the same wrapper over `tlsf_thread_t`, so a concurrent PMR user gets the
+per-arena locks instead of one global mutex. It is a separate header because
+`tlsf_thread.h` pulls in the platform's threading header and needs a lock
+backend, which a single-threaded consumer of `pmr_resource` should not have to
+supply:
+
+```cpp
+#include "tlsf_thread_pmr.hpp"
+
+alignas(TLSF_CACHELINE_SIZE) static unsigned char thread_memory[256 * 1024];
+
+tlsf_thread_t ts;
+if (!tlsf_thread_init(&ts, thread_memory, sizeof(thread_memory)))
+    return -1;
+
+tlsf::pmr_thread_resource res(ts);
+```
+
+Both are non-owning views: the pool and the resource must outlive every
+allocation, since a `std::pmr` container calls back into the resource when it
+is destroyed. Every allocation routes through `tlsf_aalloc()`, so a container
+of over-aligned elements gets the alignment it asked for. Exhaustion throws
+`std::bad_alloc`; with exceptions disabled it calls `std::terminate()` instead,
+since `memory_resource` may not return a null allocation. That kills the
+process, and `std::set_terminate()` is the only hook, so a caller for which
+exhaustion is a recoverable condition should use `tlsf_aalloc()` directly
+rather than reach the allocator through PMR. Neither adds locking of its own.
+`pmr_resource` is unsynchronized exactly like the C allocator, and
+`pmr_thread_resource` inherits the contracts in `tlsf_thread.h`.
+
+Be precise about what the O(1) claim covers, because reaching TLSF through PMR
+does not widen it. Bounded is the allocator's own work on one call: finding a
+fit is two bitmap scans, and splitting and coalescing are constant-time. Four
+costs sit outside that bound, and PMR changes none of them.
+
+| Cost | Why it is still there |
+|------|----------------------|
+| Container growth | A `std::pmr::vector` that outgrows its capacity allocates once and then moves every element it already held, so `push_back()` is O(n) in the worst case however fast the allocation was. |
+| External fragmentation | The size classes bound *internal* fragmentation to about 3.125%. Whether a request finds a large enough free block still depends on the order the caller allocated and freed; when none exists, `do_allocate()` throws `std::bad_alloc`, or terminates where exceptions are disabled. |
+| Virtual dispatch | Every allocation through a `memory_resource` is an indirect call that a direct `tlsf_malloc()` is not. |
+| Lock waits | For `pmr_thread_resource` only. Per-arena locking makes contention less likely; it does not bound how long a thread waits once contended. |
+
+A latency budget has to account for all four on top of the allocator's own
+bound.
+
 ## How It Works
 
 TLSF keeps free blocks pre-sorted into size classes, and keeps one bit per class
@@ -331,10 +399,6 @@ lists the timing sources, the raw-sample options, and a sample run.
 M. Masmano, I. Ripoll, A. Crespo, and J. Real.
 TLSF: a new dynamic memory allocator for real-time systems.
 In Proc. ECRTS (2004), IEEE Computer Society, pp. 79-86.
-
-## Related Projects
-
-* [tlsf-pmr](https://github.com/LiemDQ/tlsf-pmr): C++17 PMR allocator using TLSF
 
 ## Licensing
 

--- a/docs/configuration-and-verification.md
+++ b/docs/configuration-and-verification.md
@@ -169,10 +169,29 @@ Four consequences worth knowing:
 Frama-C is exempted from the renaming, since it analyses one translation unit at
 a time and the suffixes would invalidate the `-wp-fct` list in the Makefile.
 
+The C++ adapters would be a hole in all of this if they were left untagged. A
+class defined in a header has weak definitions for its vtable and its inline
+virtual functions, and those mangled names carry no configuration, so two
+mismatched units emit the same `do_allocate` twice. A linker that keeps one
+COMDAT group and discards the other discards the reference to the suffixed C
+symbol along with it, and the undefined reference that should have failed the
+link is gone. Both classes therefore sit in an inline namespace named by the
+same suffix, `pmr_resource` by the core one and `pmr_thread_resource` by the
+wider thread one. An inline namespace is transparent to lookup, so callers
+still write `tlsf::pmr_resource`.
+
 `.ci/check-abi-guard.sh` tests both directions: a mismatched pair must fail to
 link, and a matched pair must still build and run. The second half matters as
 much as the first, because a guard that rejects legitimate builds is worse than
 no guard.
+
+For the C++ classes it compares mangled names instead of link outcomes, because
+whether a mismatch reaches the linker is a property of the object format: Mach-O
+keeps the discarded copy's reference and rejects the link either way, so a link
+test would pass there while proving nothing. The three cases are that
+`TLSF_MAX_POOL_BITS` changes `pmr_resource`'s mangled `do_allocate`, that
+`TLSF_ARENA_COUNT` changes `pmr_thread_resource`'s, and that a thread-only knob
+leaves `pmr_resource` alone.
 
 ## Verification
 
@@ -235,8 +254,8 @@ make check TLSF_DEBUG_FLAGS=    # the same, compiled the way the library ships
 ```
 
 `make check` runs the core test and the three benchmark configurations under
-`MALLOC_CHECK_=3`, then the WCET harness, the thread stress test and the C++
-compile test.
+`MALLOC_CHECK_=3`, then the WCET harness, the thread stress test, the C++
+compile test and the `std::pmr` test.
 
 `tests/test.c` is the core suite: randomized allocate/free/realloc storms
 against a pool, with `tlsf_check()` run periodically rather than after every
@@ -251,7 +270,37 @@ public function, and address reuse.
 realloc and aligned allocation across threads, with `tlsf_thread_check()`
 verifying every arena afterwards. `tests/test_cpp.cpp` compiles the public
 headers as C++ and exercises the API, which is what keeps them free of C-only
-constructs. `tests/fuzz.c` is covered below.
+constructs; it stays at C++11, which is the baseline the headers promise.
+
+`tests/test_pmr.cpp` covers the optional adapters and is the one target built
+at C++17. It fills a `std::pmr::vector` of an over-aligned element through both
+resources, checking the alignment after every `push_back()` so the reallocation
+path counts rather than only the first block, and it pins the three behaviours
+a PMR consumer depends on: exhaustion raises `std::bad_alloc`, a request past
+the largest arena fails even though the arenas together hold more, and distinct
+resources over one pool never compare equal. The equality assertions go through
+`is_equal()` rather than `==`. `operator==` is specified as
+`&a == &b || a.is_equal(b)`, so a same-object comparison short-circuits before
+the class is reached, while a distinct-object comparison does reach it but is
+satisfied by any override that answers false. Neither case catches a
+`do_is_equal()` stuck at false, which is how the first version of this test
+passed while testing nothing.
+
+Because the adapters need a newer toolchain than the library itself does, the
+Makefile probes for `<memory_resource>` and drops the target when it is absent,
+printing `test_pmr: skipped`. An optional header must not become a floor under
+the whole build.
+
+Exceptions are not part of that floor either. `-fno-exceptions` is ordinary in
+embedded C++, and under it the adapters call `std::terminate()` on exhaustion,
+the only non-null failure outcome a `memory_resource` can offer. A CI job
+builds the whole tree that way. The first three checks above all reach
+exhaustion through a `throw`, so they are compiled out there and the parenthesis
+they would otherwise be reported under does not exist; what replaces them is a
+`fork()` whose child allocates past the pool and must die on `SIGABRT`. Without
+it the job would prove only that the headers compile, and a `do_allocate()`
+that returned the null pointer instead of terminating would pass.
+`tests/fuzz.c` is covered below.
 
 How much of the allocator all of that reaches is measured rather than assumed:
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -409,3 +409,43 @@ arenas under contention, so a pathological hash collision stays collided. And it
 does not thread-cache: every allocation takes a lock, unlike jemalloc's
 `tcache`, which serves most allocations without one. Both are deliberate, since
 both cost determinism, which is the property this allocator exists to provide.
+
+### C++ std::pmr adapters
+
+`include/tlsf_pmr.hpp` and `include/tlsf_thread_pmr.hpp` are optional,
+header-only C++17 views that present `tlsf_t` and `tlsf_thread_t` as a
+`std::pmr::memory_resource`. They are two files rather than one for the reason
+`tlsf.h` and `tlsf_thread.h` are: including the thread header pulls in the
+platform's threading header and needs a lock backend, which a single-threaded
+consumer of `pmr_resource` should not have to supply.
+
+Neither owns a pool, and neither adds locking. `pmr_resource` is unsynchronized
+exactly as the C allocator is. `pmr_thread_resource` inherits the per-arena
+locking, arena selection and quiescence contracts above rather than layering a
+second policy on them, which means the partitioning trade-off above reaches PMR
+unchanged: a `std::pmr` container asking for more than roughly 1/N of the pool
+gets `std::bad_alloc` while the other arenas sit idle. Per-arena locking lowers
+contention; it is not a jitter-free guarantee.
+
+Every allocation routes through `tlsf_aalloc()` or `tlsf_thread_aalloc()`,
+since `std::pmr` always states the alignment it needs and `tlsf_malloc()`
+promises only the natural one. A null return becomes `std::bad_alloc`. Where
+the build has no exceptions it becomes `std::terminate()` instead, because
+`do_allocate()` may not return null and not returning at all is the only
+conforming outcome left; `std::set_terminate()` is the only hook over it. That
+makes exhaustion a process kill rather than an error a caller can act on, so
+code that treats a full pool as a recoverable condition belongs on
+`tlsf_aalloc()` directly and not on PMR. The
+deallocation size and alignment `std::pmr` supplies are dropped, because the
+block header already carries the size. Equality is object identity, which is
+conservative: two wrappers over one pool are interchangeable in fact, and
+saying so would mean recovering the other resource's type through a
+`dynamic_cast` and so requiring RTTI, which these headers do not. The cost is
+that a container moving between two such resources moves elements rather than
+stealing the buffer.
+
+Each class lives in an inline namespace named by the configuration suffix its
+own C symbols carry, the core knobs for `pmr_resource` and the wider thread set
+for `pmr_thread_resource`, so two translation units that disagree about a
+layout knob cannot silently share one definition. See
+[Configuration mismatch guard](configuration-and-verification.md#configuration-mismatch-guard).

--- a/include/tlsf_pmr.hpp
+++ b/include/tlsf_pmr.hpp
@@ -1,0 +1,191 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * tlsf-bsd is freely redistributable under the BSD License. See the file
+ * "LICENSE" for information on usage and redistribution of this file.
+ */
+
+#pragma once
+
+/* Optional C++17 adapter exposing the allocator through
+ * 'std::pmr::memory_resource', the interface most modern C++ consumers accept.
+ * Nothing else in the project includes this header, so the library keeps its
+ * C11 baseline; only a translation unit that includes it needs C++17.
+ *
+ * The thread-safe wrapper has its own adapter in tlsf_thread_pmr.hpp, split off
+ * for the reason tlsf.h and tlsf_thread.h are two files: including the thread
+ * header drags in '<pthread.h>' or '<windows.h>', and on a target with no lock
+ * backend it does not compile at all until the caller defines TLSF_LOCK_T. A
+ * single-threaded consumer of this adapter should not have to pay either.
+ *
+ * The adapter is a non-owning view over a pool the caller already built. The
+ * pool, the allocator instance and the resource must all outlive every
+ * allocation made through them, because a 'std::pmr' container holds the
+ * resource pointer and calls back into it at destruction.
+ *
+ * It adds no locking, so it is unsynchronized exactly as the C allocator is.
+ *
+ * Exceptions are optional. Where they are off, exhaustion terminates rather
+ * than throwing, for the reason '_TLSF_PMR_EXCEPTIONS' gives below. The two
+ * modes must not be mixed in one binary: 'do_allocate()' is an inline virtual,
+ * so its two bodies mangle the same and the linker keeps whichever copy it saw
+ * first. That is not a hole these adapters open, since the standard library's
+ * own headers are conditioned on the same macro, but a caller linking a
+ * '-fno-exceptions' object into an exception-enabled program should know
+ * exhaustion may terminate it.
+ */
+
+/* MSVC leaves '__cplusplus' at 199711L unless '/Zc:__cplusplus' is passed, and
+ * '/std:c++17' does not imply it. Reading that macro alone would reject a
+ * compiler that supports everything below, on the flag a user reaches first.
+ * '_MSVC_LANG' always carries the real value, and only a compiler in MSVC's
+ * compatibility mode defines it at all, clang-cl included, where it is the
+ * value to read for the same reason. Testing it first costs nothing elsewhere.
+ */
+#if defined(_MSVC_LANG)
+#define _TLSF_PMR_LANG _MSVC_LANG
+#elif defined(__cplusplus)
+#define _TLSF_PMR_LANG __cplusplus
+#else
+#define _TLSF_PMR_LANG 0L
+#endif
+
+#if _TLSF_PMR_LANG < 201703L
+#error tlsf_pmr.hpp needs C++17. The library itself stays C11 and C++11.
+#endif
+
+#undef _TLSF_PMR_LANG
+
+/* Exceptions are not required. 'do_allocate()' may not return null, so with
+ * them off the only conforming outcome left is not to return at all:
+ * std::terminate(), whose default handler aborts and which std::set_terminate()
+ * lets a caller redirect. That is a process kill, not an error report, so a
+ * caller for which exhaustion is a recoverable condition should reach
+ * tlsf_aalloc() directly rather than through PMR.
+ *
+ * Written once here because tlsf_thread_pmr.hpp and tests/test_pmr.cpp need the
+ * same answer and two spellings of one feature test drift apart. Left defined,
+ * unlike '_TLSF_PMR_LANG' above, for exactly that reason.
+ */
+#if defined(__cpp_exceptions) || defined(_CPPUNWIND)
+#define _TLSF_PMR_EXCEPTIONS 1
+#else
+#define _TLSF_PMR_EXCEPTIONS 0
+#endif
+
+#include <cstddef>
+#include <exception>
+#include <memory_resource>
+#include <new>
+
+#include "tlsf.h"
+
+/* The namespace name, spelled through a macro because clang-format rewrites the
+ * closing comment of a namespace whose name is a macro invocation and then
+ * rejects what it wrote, so the file never converges under the formatter. A
+ * plain identifier is stable. Reusing '_TLSF_ABI' rather than restating the
+ * knob list is deliberate: a knob added to tlsf.h reaches this file for free.
+ */
+#define _TLSF_PMR_NS _TLSF_ABI(abi)
+
+namespace tlsf
+{
+
+/* What a full pool does, named once so the two adapters cannot answer it
+ * differently. Both call it and neither spells the branch itself.
+ *
+ * Outside the configuration-tagged namespace below on purpose: the exceptions
+ * mode is not a TLSF configuration knob, and this body is byte-identical under
+ * every one of them, so tagging it would suggest a dependency that is not
+ * there.
+ */
+[[noreturn]] inline void pmr_exhausted()
+{
+#if _TLSF_PMR_EXCEPTIONS
+    throw std::bad_alloc();
+#else
+    std::terminate();
+#endif
+}
+
+/* The inline namespace below carries the same configuration suffix the C
+ * headers paste onto their symbol names, for the same reason and against a hole
+ * the C++ side would otherwise open in that guard.
+ *
+ * A class defined in a header has weak definitions for its vtable and its
+ * inline virtuals, and their mangled names say nothing about the configuration
+ * the translation unit was compiled with. Two units that disagree about, say,
+ * TLSF_MAX_POOL_BITS emit the same mangled 'do_allocate' twice, and a linker
+ * that discards one COMDAT group discards that copy's reference to the suffixed
+ * C symbol along with it. The undefined reference that would have failed the
+ * link disappears, and one unit's 'tlsf_t' is then read at the other's offsets.
+ * Suffixing the namespace makes the two configurations' classes distinct types,
+ * so neither definition can stand in for the other.
+ *
+ * Callers still write 'tlsf::pmr_resource'; an inline namespace is transparent
+ * to name lookup. Only a hand-written forward declaration of the class would
+ * notice, and that fails to compile rather than mislinking.
+ *
+ * tlsf_thread_pmr.hpp tags its own class with the wider thread suffix. The two
+ * are separate because 'tlsf_thread_t' also moves with the arena count, the
+ * cache line and the lock backend, and tagging 'pmr_resource' with those would
+ * reject builds differing only in a knob it does not touch.
+ */
+inline namespace _TLSF_PMR_NS
+{
+
+/* Adapter over a single 'tlsf_t'. Every allocation goes through tlsf_aalloc(),
+ * since 'std::pmr' always states the alignment it needs and tlsf_malloc() only
+ * promises the natural one.
+ */
+class pmr_resource final : public std::pmr::memory_resource
+{
+public:
+    explicit pmr_resource(tlsf_t &pool) noexcept : pool_(&pool) {}
+
+    pmr_resource(const pmr_resource &) = delete;
+    pmr_resource &operator=(const pmr_resource &) = delete;
+
+private:
+    void *do_allocate(std::size_t bytes, std::size_t alignment) override
+    {
+        void *p = tlsf_aalloc(pool_, alignment, bytes);
+        if (!p)
+            pmr_exhausted();
+        return p;
+    }
+
+    /* The byte count and alignment are redundant here: TLSF stores the block
+     * size in the header ahead of the payload, so it needs neither.
+     */
+    void do_deallocate(void *p, std::size_t, std::size_t) override
+    {
+        tlsf_free(pool_, p);
+    }
+
+    /* Object identity, the answer the standard's own pool resources give.
+     *
+     * Two 'pmr_resource' objects over one 'tlsf_t' are interchangeable in fact,
+     * since tlsf_free() takes the pool and not the wrapper, so a strict reading
+     * of do_is_equal() would have that pair answer true. Comparing pools means
+     * recovering the other resource's type through a dynamic_cast, which the
+     * standard's note on this function contemplates and which needs RTTI. These
+     * headers compile under -fno-rtti, the mode a good deal of embedded C++
+     * builds in, and the conservative answer costs only a container's chance to
+     * steal a buffer on move assignment or swap rather than moving elements one
+     * at a time. Nothing is freed through the wrong pool either way.
+     */
+    bool do_is_equal(
+        const std::pmr::memory_resource &other) const noexcept override
+    {
+        return this == &other;
+    }
+
+    tlsf_t *pool_;
+};
+
+} /* namespace _TLSF_PMR_NS */
+
+} /* namespace tlsf */

--- a/include/tlsf_thread_pmr.hpp
+++ b/include/tlsf_thread_pmr.hpp
@@ -1,0 +1,108 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * tlsf-bsd is freely redistributable under the BSD License. See the file
+ * "LICENSE" for information on usage and redistribution of this file.
+ */
+
+#pragma once
+
+/* Optional C++17 adapter exposing the thread-safe wrapper through
+ * 'std::pmr::memory_resource'. Split from tlsf_pmr.hpp so that a consumer of
+ * the single-threaded adapter does not pull in '<pthread.h>' or '<windows.h>',
+ * and is not stopped outright on a target where tlsf_thread.h has no lock
+ * backend to select. Including this header is the same opt-in as including
+ * tlsf_thread.h, and needs the same TLSF_LOCK_T obligations.
+ *
+ * A non-owning view, like its sibling. The pool, the 'tlsf_thread_t' and the
+ * resource must all outlive every allocation, because a 'std::pmr' container
+ * holds the resource pointer and calls back into it at destruction.
+ *
+ * It adds no locking of its own. The per-arena locking, arena selection and
+ * quiescence contracts are the ones tlsf_thread.h documents, and this wrapper
+ * inherits them rather than layering a second policy on top. Per-arena locking
+ * lowers contention; it is not a jitter-free guarantee. A hard latency bound
+ * still needs a single-owner resource or a platform-specific lock bound.
+ */
+
+/* Depends on the core adapter the way tlsf_thread.h depends on tlsf.h, and for
+ * the same reason: the wrapper is built on the allocator, not beside it. It
+ * also means the C++17 language gate is written once, in the file both include
+ * paths reach, instead of twice in two spellings that can drift apart.
+ *
+ * Ahead of the standard headers so that gate is what a pre-C++17 build reports.
+ * A toolchain old enough to lack '<memory_resource>' entirely would otherwise
+ * fail on a missing file, naming a header the reader never asked for instead of
+ * the language level that is actually wrong.
+ */
+#include "tlsf_pmr.hpp"
+
+#include <cstddef>
+#include <memory_resource>
+
+#include "tlsf_thread.h"
+
+/* Spelled through a macro for the reason tlsf_pmr.hpp gives, and derived from
+ * '_TLSF_THREAD_ABI' because 'tlsf_thread_t' moves with the arena count, the
+ * cache line and the lock backend on top of the core knobs.
+ */
+#define _TLSF_PMR_THREAD_NS _TLSF_THREAD_ABI(abi)
+
+namespace tlsf
+{
+
+/* Configuration-tagged for the reason tlsf_pmr.hpp sets out at length: a class
+ * defined in a header has weak definitions whose mangled names carry no
+ * configuration, which is a way around the suffixed C symbol names.
+ */
+inline namespace _TLSF_PMR_THREAD_NS
+{
+
+/* Adapter over a 'tlsf_thread_t'. Two hand-written classes rather than one
+ * parameterized on the pool type, because the two must land in differently
+ * suffixed inline namespaces and a template's instantiations mangle into the
+ * namespace where the template is declared, not where it is used. A shared
+ * template would put this class's vtable and inline virtuals under the core
+ * suffix, leaving the guard resting on how a compiler spells a function-pointer
+ * template argument. Thirty lines is the cheaper side of that trade.
+ */
+class pmr_thread_resource final : public std::pmr::memory_resource
+{
+public:
+    explicit pmr_thread_resource(tlsf_thread_t &pool) noexcept : pool_(&pool) {}
+
+    pmr_thread_resource(const pmr_thread_resource &) = delete;
+    pmr_thread_resource &operator=(const pmr_thread_resource &) = delete;
+
+private:
+    void *do_allocate(std::size_t bytes, std::size_t alignment) override
+    {
+        void *p = tlsf_thread_aalloc(pool_, alignment, bytes);
+        if (!p)
+            pmr_exhausted();
+        return p;
+    }
+
+    void do_deallocate(void *p, std::size_t, std::size_t) override
+    {
+        tlsf_thread_free(pool_, p);
+    }
+
+    /* Object identity, with the trade-off tlsf_pmr.hpp sets out: two wrappers
+     * over one 'tlsf_thread_t' are interchangeable in fact, and saying so would
+     * take a dynamic_cast and therefore RTTI.
+     */
+    bool do_is_equal(
+        const std::pmr::memory_resource &other) const noexcept override
+    {
+        return this == &other;
+    }
+
+    tlsf_thread_t *pool_;
+};
+
+} /* namespace _TLSF_PMR_THREAD_NS */
+
+} /* namespace tlsf */

--- a/src/tlsf.c
+++ b/src/tlsf.c
@@ -1591,6 +1591,14 @@ void *tlsf_malloc(tlsf_t *t, size_t size)
     return block_use(t, block, size);
 }
 
+/* The bound below subtracts 'align' and the block struct from TLSF_MAX_SIZE,
+ * and that subtraction leans on the power-of-two test two lines above it: the
+ * largest power of two not exceeding TLSF_MAX_SIZE is under half of it, which
+ * leaves the remainder well clear of zero. 64-bit gives TLSF_MAX_SIZE 2^31 - 8
+ * against a largest align of 2^30, 32-bit gives 2^24 - 4 against 2^23. Relaxing
+ * either the power-of-two requirement or TLSF_MAX_SIZE reintroduces an
+ * underflow here that admits a size the arithmetic below cannot hold.
+ */
 void *tlsf_aalloc(tlsf_t *t, size_t align, size_t size)
 {
     size_t adjust = adjust_size(size, ALIGN_SIZE);

--- a/src/tlsf.c
+++ b/src/tlsf.c
@@ -536,10 +536,11 @@ INLINE char *block_payload(tlsf_block_t *block)
 INLINE tlsf_block_t *to_block(void *ptr)
 {
     tlsf_block_t *block = (tlsf_block_t *) ptr;
+
     /* align_offset(), not align_ptr(): this only tests alignment, and
-     * align_ptr() would additionally require the caller to own a full
-     * alignment window that to_block() cannot promise. The two are
-     * equivalent here, since align_ptr(p, a) is p + align_offset(p, a).
+     * align_ptr() would additionally require the caller to own a full alignment
+     * window that to_block() cannot promise. The two are equivalent here, since
+     * align_ptr(p, a) is p + align_offset(p, a).
      */
     ASSERT(align_offset(block_payload(block), ALIGN_SIZE) == 0,
            "block not aligned properly");
@@ -760,18 +761,14 @@ INLINE size_t adjust_size(size_t size, size_t align)
     return size < BLOCK_SIZE_MIN ? BLOCK_SIZE_MIN : size;
 }
 
-/* Round up to the next block size. Branch-free: for small sizes (<
- * BLOCK_SIZE_SMALL), the rounding mask is zero, producing an identity. For
- * large sizes, it rounds up to the next second-level bin boundary.
- */
 /* Second-level bin mask: all-zero below BLOCK_SIZE_SMALL, where bins are
  * linear, and (1 << shift) - 1 above it. Both rounding directions need it, so
  * it lives here rather than twice.
  *
  * The shift clamp is load-bearing, not defensive: an aligned size still only
  * gives lg >= ALIGN_SHIFT, so lg - SL_SHIFT wraps for the smallest sizes and
- * would be undefined without it. The wrapped value is harmless because
- * is_large is zero there and zero shifted by anything is zero.
+ * would be undefined without it. The wrapped value is harmless because is_large
+ * is zero there and zero shifted by anything is zero.
  */
 /*@
   requires size > 0;
@@ -787,6 +784,10 @@ INLINE size_t block_size_mask(size_t size)
     return (is_large << shift) - is_large;
 }
 
+/* Round up to the next block size. Branch-free: for small sizes (<
+ * BLOCK_SIZE_SMALL), the rounding mask is zero, producing an identity. For
+ * large sizes, it rounds up to the next second-level bin boundary.
+ */
 /*@
   requires size > 0;
   requires size <= TLSF_MAX_SIZE;
@@ -799,8 +800,8 @@ INLINE size_t round_block_size(size_t size)
     return (size + t) & ~t;
 }
 
-/* The inverse direction: the largest request this block size can serve, since
- * a request is rounded up and must still fit. Takes any mappable block size,
+/* The inverse direction: the largest request this block size can serve, since a
+ * request is rounded up and must still fit. Takes any mappable block size,
  * including one above TLSF_MAX_SIZE, which coalescing and pool appends do
  * build; capping belongs to the caller and cannot be done first without
  * under-reporting.

--- a/src/tlsf_thread.c
+++ b/src/tlsf_thread.c
@@ -22,7 +22,17 @@ static TLSF_THREAD_LOCAL unsigned int tlsf_thread_id = 0;
 static inline unsigned int get_thread_hint(void)
 {
 #if defined(TLSF_THREAD_LOCAL)
-    return (unsigned) ((uintptr_t) &tlsf_thread_id);
+    /* Fold the whole address in before narrowing to 'unsigned'. A target that
+     * spaces thread local blocks more than 4 GB apart hands every thread the
+     * same low half, and arena_select() would then send all of them to arena 0
+     * and forfeit the per-arena locking entirely.
+     *
+     * Two 16-bit shifts rather than one 32-bit: where uintptr_t is 32 bits a
+     * shift by the full width is undefined, and this pair yields zero there,
+     * which leaves the value unchanged as it must be.
+     */
+    uintptr_t p = (uintptr_t) &tlsf_thread_id;
+    return (unsigned) (p ^ (p >> 16 >> 16));
 #elif defined(TLSF_THREAD_HINT)
     return TLSF_THREAD_HINT();
 #else

--- a/tests/test_pmr.cpp
+++ b/tests/test_pmr.cpp
@@ -1,0 +1,310 @@
+/*
+ * Exercises the optional std::pmr adapters, tlsf_pmr.hpp and
+ * tlsf_thread_pmr.hpp.
+ *
+ * Kept apart from tests/test_cpp.cpp, which pins the public headers to C++11.
+ * The adapters need C++17 for <memory_resource>, and that requirement must not
+ * leak into the baseline the library itself promises.
+ */
+
+#include <cstdint>
+#include <cstdio>
+#include <memory_resource>
+#include <new>
+#include <thread>
+#include <vector>
+
+#include "tlsf_pmr.hpp"
+#include "tlsf_thread_pmr.hpp"
+
+#include "pool_limits.h"
+
+/* Without exceptions the only outcome left to check is the process dying, and
+ * that needs a child to die in.
+ */
+#if !_TLSF_PMR_EXCEPTIONS && !defined(_WIN32)
+#include <csignal>
+
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
+#define CHECK(cond)                                                    \
+    do {                                                               \
+        if (!(cond)) {                                                 \
+            fprintf(stderr, "%s:%d: %s\n", __FILE__, __LINE__, #cond); \
+            return 1;                                                  \
+        }                                                              \
+    } while (0)
+
+/* One element per cache line, so a container of these asks the resource for an
+ * alignment stricter than the allocator's natural one.
+ */
+struct alignas(64) cacheline {
+    std::uint64_t value;
+};
+
+/* Both fixtures are clamped to what the build configuration can hold, the way
+ * every other test in this directory sizes its pool.
+ *
+ * The threaded fixture is sized per arena and multiplied up, not carved out of
+ * a fixed total. Memory is partitioned, so what matters is that one arena can
+ * serve the largest request the test makes of it, and dividing a fixed total by
+ * TLSF_ARENA_COUNT fails that at a high count: at 64 arenas a 256 KiB total
+ * leaves 4 KiB each, which is less than one finished vector.
+ *
+ * The floor is derived rather than picked, and derived for the worst growth
+ * policy rather than the local one. A fill_vector() run grows a vector to 64
+ * 'cacheline' elements, and its last growth holds the old buffer while
+ * allocating the new one. Doubling, which libstdc++ and libc++ use, reaches 64
+ * exactly and peaks at 32 + 64 = 96 elements live. MSVC grows by 1.5, so its
+ * capacities run 63 then 94 and it peaks at 157. Both workers can land on one
+ * arena, taking that to 314, and every block carries a header on top. 512
+ * elements' worth covers it with room for those headers and the pool's own
+ * sentinel.
+ *
+ * Sizing this from the local growth factor would have passed everywhere it was
+ * run and failed only in the MSVC job, which is the one place this test cannot
+ * be reproduced from a POSIX host.
+ */
+#define CORE_BYTES TLSF_TEST_POOL_CLAMP(64 * 1024)
+
+#define THREAD_ARENA_BYTES (512 * sizeof(cacheline))
+#define THREAD_BYTES \
+    (TLSF_TEST_POOL_CLAMP(THREAD_ARENA_BYTES) * TLSF_ARENA_COUNT)
+
+alignas(64) static unsigned char core_memory[CORE_BYTES];
+alignas(TLSF_CACHELINE_SIZE) static unsigned char thread_memory[THREAD_BYTES];
+
+static bool is_aligned(const void *p, std::size_t align)
+{
+    return (reinterpret_cast<std::uintptr_t>(p) & (align - 1)) == 0;
+}
+
+/* A request no pool can serve must be reported, never answered with a null
+ * pointer, which is what every std::pmr consumer expects. How it is reported is
+ * what the build decides, so the mode picks a body here once and every caller
+ * asks the same question.
+ *
+ * With exceptions, catch the std::bad_alloc. The block is returned on the path
+ * that must not be taken, so a regression shows up as a failed check and not as
+ * a leak.
+ *
+ * Without them the pass condition is that the child never comes back:
+ * 'do_allocate()' may not return null, so std::terminate() aborts through its
+ * default handler, and any other outcome, a clean exit above all, means the
+ * null leaked out to the caller. The child's stderr goes to /dev/null because
+ * the runtime prints a line there before aborting, and an expected failure that
+ * looks like a crash in the log is how a real one gets missed.
+ */
+#if _TLSF_PMR_EXCEPTIONS || !defined(_WIN32)
+#define HAVE_EXHAUSTION_CHECK 1
+static bool fails_on_exhaustion(std::pmr::memory_resource *res,
+                                std::size_t bytes)
+{
+#if _TLSF_PMR_EXCEPTIONS
+    try {
+        void *p = res->allocate(bytes, 8);
+        res->deallocate(p, bytes, 8);
+    } catch (const std::bad_alloc &) {
+        return true;
+    }
+    return false;
+#else
+    pid_t child = fork();
+    if (child == 0) {
+        if (!freopen("/dev/null", "w", stderr))
+            _exit(2);
+        void *p = res->allocate(bytes, 8);
+        res->deallocate(p, bytes, 8);
+        _exit(0);
+    }
+    if (child < 0)
+        return false;
+
+    int status = 0;
+    if (waitpid(child, &status, 0) != child)
+        return false;
+    return WIFSIGNALED(status) && WTERMSIG(status) == SIGABRT;
+#endif
+}
+#else
+/* Windows with exceptions off: neither arm is available, since there is no
+ * throw to catch and no fork to die in. Nothing else in the file is skipped.
+ */
+#define HAVE_EXHAUSTION_CHECK 0
+#endif
+
+/* Grow past several reallocations, so the resource sees allocate and deallocate
+ * of differing sizes rather than a single fresh block.
+ */
+static int fill_vector(std::pmr::memory_resource *res)
+{
+    std::pmr::vector<cacheline> v(res);
+    for (std::uint64_t i = 0; i < 64; ++i) {
+        v.push_back(cacheline{i});
+        CHECK(is_aligned(v.data(), alignof(cacheline)));
+    }
+    for (std::uint64_t i = 0; i < 64; ++i)
+        CHECK(v[i].value == i);
+    return 0;
+}
+
+/* Distinct resources over one pool never compare equal, which is what a
+ * container consults before assuming it may free another's blocks.
+ *
+ * Through is_equal(), which forwards to do_is_equal() unconditionally, rather
+ * than operator==. The latter is specified as '&a == &b || a.is_equal(b)', so
+ * a same-object comparison short-circuits before the class is reached and a
+ * distinct-object comparison is satisfied by any override that answers false.
+ * Between them those two cases cannot catch a do_is_equal() stuck at false, and
+ * an earlier version of this test using operator== stayed green with both
+ * bodies replaced by 'return false'. Through is_equal() that same mutation
+ * fails the first check below.
+ */
+static int run_rounds(std::pmr::memory_resource *res)
+{
+    for (int round = 0; round < 32; ++round)
+        if (fill_vector(res) != 0)
+            return 1;
+    return 0;
+}
+
+/* An exception escaping a thread's entry point is a terminate(), which reports
+ * the failure as a crash instead of the file and line CHECK exists to print.
+ *
+ * A whole body per mode rather than a 'try' opened in one preprocessor branch
+ * and closed in another: the latter balances its braces in no configuration a
+ * reader can follow from top to bottom.
+ */
+static int run_rounds_guarded(std::pmr::memory_resource *res)
+{
+#if _TLSF_PMR_EXCEPTIONS
+    try {
+        return run_rounds(res);
+    } catch (const std::bad_alloc &) {
+        return 1;
+    }
+#else
+    return run_rounds(res);
+#endif
+}
+
+static int check_identity(std::pmr::memory_resource &res,
+                          std::pmr::memory_resource &other)
+{
+    CHECK(res.is_equal(res));
+    CHECK(!res.is_equal(other));
+    return 0;
+}
+
+/* Both instances are static for the reason tests/test_thread.c makes its own
+ * static: 'tlsf_t' is several kilobytes and 'tlsf_thread_t' is that again per
+ * arena, so a stack copy grows with TLSF_ARENA_COUNT and TLSF_CACHELINE_SIZE
+ * until it no longer fits a modest main stack.
+ */
+static tlsf_t core_pool = TLSF_INIT;
+static tlsf_thread_t thread_pool;
+
+/* The floor above is reasoned from a growth factor this toolchain may not use,
+ * so pin it with an allocation instead of trusting the reasoning: both workers'
+ * worst-case peaks must be servable at once. Without this the MSVC job would be
+ * the first to find a pool too small, and it is the one job that cannot be
+ * reproduced from a POSIX host.
+ */
+/* Peak elements live in one arena during a fill_vector() growth, taken from the
+ * 1.5 factor rather than the local one, and the two workers' share of it.
+ */
+#define GROWTH_PEAK 157
+
+/* Through the C API rather than the resource, because this asks about pool
+ * capacity and nothing else. tlsf_thread_aalloc() reports failure with a null
+ * in every build, so the check does not inherit the resource's failure policy
+ * and go missing wherever that policy cannot be observed.
+ */
+static int check_peak_fits(tlsf_thread_t *pool)
+{
+    const std::size_t peak = GROWTH_PEAK * sizeof(cacheline);
+    void *a = tlsf_thread_aalloc(pool, alignof(cacheline), peak);
+    void *b = tlsf_thread_aalloc(pool, alignof(cacheline), peak);
+
+    bool both = a && b;
+    if (a)
+        tlsf_thread_free(pool, a);
+    if (b)
+        tlsf_thread_free(pool, b);
+    CHECK(both);
+    return 0;
+}
+
+static int core_test(void)
+{
+    tlsf_t &pool = core_pool;
+    CHECK(tlsf_pool_init(&pool, core_memory, sizeof(core_memory)) > 0);
+
+    tlsf::pmr_resource res(pool);
+    CHECK(fill_vector(&res) == 0);
+    tlsf_check(&pool);
+
+    tlsf::pmr_resource other(pool);
+    CHECK(check_identity(res, other) == 0);
+
+#if HAVE_EXHAUSTION_CHECK
+    CHECK(fails_on_exhaustion(&res, sizeof(core_memory) * 2));
+#endif
+    tlsf_check(&pool);
+    return 0;
+}
+
+static int thread_test(void)
+{
+    tlsf_thread_t &pool = thread_pool;
+    CHECK(tlsf_thread_init(&pool, thread_memory, sizeof(thread_memory)) > 0);
+
+    CHECK(check_peak_fits(&pool) == 0);
+
+    tlsf::pmr_thread_resource res(pool);
+
+    int failed[2] = {0, 0};
+    std::thread workers[2];
+    for (int i = 0; i < 2; ++i) {
+        workers[i] = std::thread(
+            [&res, &failed, i] { failed[i] = run_rounds_guarded(&res); });
+    }
+    for (std::thread &w : workers)
+        w.join();
+    CHECK(!failed[0] && !failed[1]);
+    tlsf_thread_check(&pool);
+
+    /* The partition failure, which is the one a PMR user is most likely to be
+     * surprised by: tlsf_thread.h promises allocation fails when no single
+     * arena can serve the request, even where the arenas together hold far more
+     * than it asks for. A request past the largest arena but inside the total
+     * is exactly that gap. Self-skips at TLSF_ARENA_COUNT=1, where the two
+     * figures are equal and the gap does not exist.
+     */
+#if HAVE_EXHAUSTION_CHECK
+    tlsf_stats_t stats;
+    CHECK(tlsf_thread_stats(&pool, &stats) == 0);
+    if (stats.total_free > stats.largest_free)
+        CHECK(fails_on_exhaustion(&res, stats.largest_free + 1));
+
+    CHECK(fails_on_exhaustion(&res, sizeof(thread_memory) * 2));
+#endif
+
+    tlsf::pmr_thread_resource other(pool);
+    CHECK(check_identity(res, other) == 0);
+
+    tlsf_thread_check(&pool);
+    tlsf_thread_destroy(&pool);
+    return 0;
+}
+
+int main()
+{
+    int failed = core_test();
+    failed |= thread_test();
+    if (!failed)
+        printf("test_pmr: ok\n");
+    return failed;
+}


### PR DESCRIPTION
Modern C++ consumers take a std::pmr::memory_resource rather than an allocator-specific API, so every one of them had to write the virtual adapter again and get the allocation-failure and over-alignment details right on its own.

include/tlsf_pmr.hpp and include/tlsf_thread_pmr.hpp are header-only C++17 views over tlsf_t and tlsf_thread_t. Each stores one pointer and owns nothing. do_allocate() goes through tlsf_aalloc() or tlsf_thread_aalloc(), since std::pmr always states the alignment it needs while tlsf_malloc() promises only the natural one, and a null return becomes std::bad_alloc. do_deallocate() drops the size and alignment std::pmr supplies, which the block header already carries. Equality is object identity. No pool ownership, no release(), no upstream fallback, no RTTI and no added locking: tlsf_thread.h already defines the locking, arena selection and quiescence contracts, and a second policy on top would only weaken them.

Two headers rather than one, mirroring tlsf.h and tlsf_thread.h. The thread header needs a lock backend and pulls in <pthread.h> or <windows.h>, and where it selects no backend it does not compile at all, which a single-threaded user of pmr_resource should not have to pay for.

Both classes sit in an inline namespace named by the configuration suffix their own C symbols carry. Without it they are a hole in the mismatch guard: a header-defined class has weak definitions whose mangled names carry no configuration, so two mismatched units emit the same do_allocate(), and a linker that discards one COMDAT group discards that copy's reference to the suffixed C symbol with it. Two units at different TLSF_MAX_POOL_BITS linked cleanly and then segfaulted before the tagging. check-abi-guard.sh gains three cases comparing mangled names rather than link outcomes, because whether a mismatch reaches the linker is a property of the object format: Mach-O keeps the reference and rejects the link either way, so a link test would pass there while proving nothing.

The library baseline is unchanged. tests/test_cpp.cpp still compiles the public headers as C++11 and MSVC still builds it at /std:c++14. Only build/test_pmr is raised to C++17, and the Makefile probes for a usable <memory_resource> and drops that target when the probe fails, so an optional header does not become a floor under the whole build. The language gate reads _MSVC_LANG where it exists, because cl leaves __cplusplus at 199711L unless /Zc:__cplusplus is passed and /std:c++17 does not imply it; a new MSVC job step compiles the test on that exact command line.

tests/test_pmr.cpp runs in make check. It fills a std::pmr::vector of an alignas(64) element through both resources, checking alignment after every push_back so the reallocation path counts and not just the first block, then calls tlsf_check() and tlsf_thread_check(). Two std::thread workers share one pmr_thread_resource for 32 rounds each. Exhaustion must throw std::bad_alloc, a request one byte past the largest arena must fail even though the arenas together hold more, and distinct resources over one pool must compare unequal through is_equal(), which does not short-circuit on address identity the way operator== does.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional header-only C++17 `std::pmr` adapters over `tlsf_t` and `tlsf_thread_t`, so C++ consumers that take a `memory_resource` no longer write the virtual adapter themselves. The library, its public headers, and the C++11 baseline are unchanged; the `src/tlsf.c` changes are comment-only.

**New Features**

- Both headers are non-owning views routing through the aligned-allocation functions; exhaustion throws `std::bad_alloc`.
- Both classes sit in inline namespaces named by the configuration suffix, so mismatched layout knobs fail to link; `.ci/check-abi-guard.sh` confirms by comparing mangled names.
- Only `test_pmr` requires C++17; the Makefile probes for `<memory_resource>` plus exceptions, skipping the target when either is missing, and CI adds an MSVC step at `/std:c++17`.
- `tests/test_pmr.cpp` runs in `make check`, covering over-aligned vector growth, two-thread stress, exhaustion, the per-arena partition gap, and `is_equal()` identity.

**Bug Fixes**

- `get_thread_hint()` folds the whole thread-local address into the arena hint before narrowing to `unsigned`; targets that space TLS blocks more than 4 GB apart previously sent every thread to arena 0.
- A cppcheck suppression for the hint call keeps the style job green on newer cppcheck.

<sup>Written for commit b52de577a70d07cd42b6add9a2753e15b58315e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/tlsf-bsd/pull/47?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

