### PR TITLE
Add tlsf_calloc and gate branch coverage

### DIFF
--- a/.ci/check-coverage.sh
+++ b/.ci/check-coverage.sh
@@ -37,11 +37,21 @@ make clean >/dev/null
 CFLAGS="--coverage" LDFLAGS="--coverage" \
 	make all TLSF_DEBUG_FLAGS=-DTLSF_ENABLE_CHECK
 
-./build/test >/dev/null
+# Pinned so that a drop here can be re-run. tests/test.c otherwise seeds
+# itself from time(0), which leaves a failing measurement impossible to
+# reproduce. build/fuzz already defaults to a fixed seed.
+#
+# This does not make the figure deterministic by itself, and it was measured
+# rather than assumed: with the seed pinned, six consecutive runs still split
+# 208/209 on the branch count. The one that moves is an arm of the compound
+# argument guard in tlsf_aalloc(), which the thread stress test reaches
+# incidentally a handful of times in some ninety thousand calls, or not at
+# all, depending on scheduling. The floor below carries headroom for it.
+TLSF_TEST_SEED=1 ./build/test >/dev/null
 ./build/test_thread >/dev/null
 ./build/fuzz >/dev/null
 
-report="$(${GCOV} -b -o build src/tlsf.c)"
+report="$(${GCOV} -b -c -o build src/tlsf.c)"
 printf '%s\n' "$report"
 
 pct="$(printf '%s\n' "$report" |
@@ -63,3 +73,65 @@ awk -v got="$pct" -v floor="$FLOOR" 'BEGIN {
 	}
 	print msg
 }'
+
+# Branch coverage over the same run, with the CHECK() arms taken out.
+#
+# tlsf_check() and its helpers are one CHECK() after another, and the failing
+# arm of each is the corruption report a passing suite must never take. Those
+# arms are unreachable in the same way as the ASSERT lines compiled out above,
+# so counting them caps the figure at a number no test can lift.
+#
+# Counts, not the percentages gcov prints without -c: a branch taken once in
+# hundreds of millions rounds to "taken 0%" and would read as never taken.
+#
+# How far the floor sits under the measured figure was settled by measuring
+# both toolchains, not by taste. gcc and clang disagree about how a
+# short-circuit operator decomposes into branches, the same divergence the
+# unreached-line note above records, and the gap is in the denominator rather
+# than the ratio: the same suite reports 94.48% of 290 reachable branches
+# under the gcc this job runs, and 94.14% of 222 under clang. On top of that
+# the figure moves by one branch between runs, for the scheduling reason
+# recorded at the test invocation, worth 0.34 points on gcc and 0.45 on clang.
+#
+# 93 clears both toolchains with their jitter and still fails on the loss of a
+# few branches. A floor of 90 would have hidden thirteen of them on gcc, which
+# is the class of regression this gate exists to catch.
+BRANCH_FLOOR="${BRANCH_FLOOR:-93}"
+
+awk -v floor="$BRANCH_FLOOR" '
+	/^ *[^:]*: *[0-9]+:/ { src = $0 }
+	/^branch / {
+		if (src ~ /CHECK\(/)
+			next
+		total++
+		if ($4 + 0 > 0)
+			next
+		missed++
+		line = src
+		sub(/^[^:]*: */, "", line)
+		if (!(line in seen)) {
+			seen[line] = 1
+			untaken[++u] = line
+		}
+	}
+	END {
+		if (!total) {
+			print "check-coverage: no branch records in tlsf.c.gcov" \
+				> "/dev/stderr"
+			exit 1
+		}
+		print "reachable branches never taken in src/tlsf.c:"
+		for (i = 1; i <= u; i++)
+			print "  " untaken[i]
+		if (!u)
+			print "  none"
+		got = (total - missed) * 100 / total
+		msg = sprintf("check-coverage: %.2f%% of %d reachable branches in " \
+		              "src/tlsf.c (%d taken), floor %s%%",
+		              got, total, total - missed, floor)
+		if (got < floor + 0) {
+			print msg > "/dev/stderr"
+			exit 1
+		}
+		print msg
+	}' tlsf.c.gcov

--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,9 @@ FRAMAC ?= frama-c
 #
 # Read the goal count for what it is. This list is a subset of the functions
 # defined in src/tlsf.c, and tlsf_pool_reset is the only public entry point on
-# it. tlsf_malloc, tlsf_free, tlsf_realloc, tlsf_aalloc, tlsf_pool_init,
-# tlsf_append_pool, tlsf_usable_size, tlsf_check and tlsf_get_stats are all
-# unproved, as are the internal arena helpers they call.
+# it. tlsf_malloc, tlsf_calloc, tlsf_free, tlsf_realloc, tlsf_aalloc,
+# tlsf_pool_init, tlsf_append_pool, tlsf_usable_size, tlsf_check and
+# tlsf_get_stats are all unproved, as are the internal arena helpers they call.
 # Several listed helpers also have no postcondition, which means "proved" is
 # "cannot fault", not "returns the right answer": injecting a real bug into
 # align_offset still yields a fully proved run, while the same injection into

--- a/README.md
+++ b/README.md
@@ -112,9 +112,11 @@ answer". The `WP_FUNCTIONS` list in the Makefile states the exact scope.
 /* Dynamic pool (auto-growing): user must define tlsf_resize() */
 tlsf_t t = TLSF_INIT;
 void *p = tlsf_malloc(&t, 256);
+void *z = tlsf_calloc(&t, 4, 64);
 void *q = tlsf_aalloc(&t, 64, 256);   /* 64-byte aligned */
 p = tlsf_realloc(&t, p, 512);
 tlsf_free(&t, p);
+tlsf_free(&t, z);
 tlsf_free(&t, q);
 
 /* Static pool (fixed-size): no tlsf_resize() needed */
@@ -130,6 +132,7 @@ tlsf_free(&s, r);
 | Function | Description |
 |----------|-------------|
 | `tlsf_malloc(t, size)` | Allocate `size` bytes. Zero `size` returns a unique minimum-sized block. |
+| `tlsf_calloc(t, nmemb, size)` | Allocate an array and zero its requested bytes. Multiplication overflow returns NULL. |
 | `tlsf_free(t, ptr)` | Free a previously allocated block. NULL is a no-op. |
 | `tlsf_realloc(t, ptr, size)` | Resize allocation. Tries in-place expansion before relocating. |
 | `tlsf_aalloc(t, align, size)` | Allocate with alignment. `align` must be a power of two. |

--- a/docs/configuration-and-verification.md
+++ b/docs/configuration-and-verification.md
@@ -387,7 +387,7 @@ Frama-C's WP plugin with runtime-error generation over the list in
 
 Read the result for what it is. The list is a subset of the functions in the
 file, and `tlsf_pool_reset` is the only public entry point on it: `tlsf_malloc`,
-`tlsf_free`, `tlsf_realloc`, `tlsf_aalloc`, `tlsf_pool_init`,
+`tlsf_calloc`, `tlsf_free`, `tlsf_realloc`, `tlsf_aalloc`, `tlsf_pool_init`,
 `tlsf_append_pool`, `tlsf_usable_size`, `tlsf_check` and `tlsf_get_stats` are
 all unproved, as are the arena helpers they call. Because no caller of the
 proved helpers is in the list, every `requires` is an assumed hypothesis rather

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -209,6 +209,7 @@ caller layered on top will run.
 | Operation | Cost | Note |
 |-----------|------|------|
 | `tlsf_malloc` | O(1) | two bitmap scans, one unlink, at most one split |
+| `tlsf_calloc` | O(1) + O(bytes) | `tlsf_malloc` plus zeroing the requested bytes |
 | `tlsf_free` | O(1) | at most two merges, one insert |
 | `tlsf_realloc` | O(1) forward or shrink | backward growth and relocation each copy the payload once |
 | `tlsf_aalloc` | O(1) | one extra split at the front |

--- a/include/tlsf.h
+++ b/include/tlsf.h
@@ -266,7 +266,7 @@ typedef struct {
   predicate tlsf_payload_header{L}(void *ptr) =
     \valid((char *)ptr) &&
     \valid(((char *)ptr - sizeof(size_t)) + (0 .. sizeof(size_t) - 1));
-*/
+ */
 
 /**
  * Callback to grow or query the memory arena (dynamic pools only). Users of
@@ -286,7 +286,7 @@ typedef struct {
   requires \valid(t);
   requires size <= ((size_t)1 << _TLSF_FL_MAX);
   ensures \result == \null || \valid(((char *)\result) + (0 .. size - 1));
-*/
+ */
 void *tlsf_resize(tlsf_t *t, size_t size);
 
 /**
@@ -307,7 +307,7 @@ void *tlsf_resize(tlsf_t *t, size_t size);
   requires \valid(t);
   ensures (align == 0 || (align & (align - 1)) != 0) ==> \result == \null;
   ensures \result == \null || \valid(((char *)\result) + (0 .. size - 1));
-*/
+ */
 void *tlsf_aalloc(tlsf_t *t, size_t align, size_t size);
 
 /**
@@ -330,7 +330,7 @@ void *tlsf_aalloc(tlsf_t *t, size_t align, size_t size);
   requires mem != \null && size != 0 ==>
     \valid(((char *)mem) + (0 .. size - 1));
   ensures \result <= size;
-*/
+ */
 size_t tlsf_append_pool(tlsf_t *t, void *mem, size_t size);
 
 /**
@@ -358,7 +358,7 @@ size_t tlsf_append_pool(tlsf_t *t, void *mem, size_t size);
   requires mem != \null && bytes != 0 ==>
     \valid(((char *)mem) + (0 .. bytes - 1));
   ensures \result == 0 || t->fixed;
-*/
+ */
 size_t tlsf_pool_init(tlsf_t *t, void *mem, size_t bytes);
 
 /**
@@ -397,13 +397,13 @@ void tlsf_pool_reset(tlsf_t *t);
  * allocation.
  *
  * On 32-bit the resulting 4 bytes is under _Alignof(max_align_t), 16 on i386,
- * so this is not a conforming malloc() substitute there for over-aligned
- * types. Use tlsf_aalloc(), which takes the alignment explicitly.
+ * so this is not a conforming malloc() substitute there for over-aligned types.
+ * Use tlsf_aalloc(), which takes the alignment explicitly.
  */
 /*@
   requires \valid(t);
   ensures \result == \null || \valid(((char *)\result) + (0 .. size - 1));
-*/
+ */
 void *tlsf_malloc(tlsf_t *t, size_t size);
 
 /**
@@ -429,7 +429,7 @@ void *tlsf_malloc(tlsf_t *t, size_t size);
   requires \valid(t);
   requires mem != \null ==> tlsf_payload_header(mem);
   ensures \result == \null || \valid(((char *)\result) + (0 .. size - 1));
-*/
+ */
 void *tlsf_realloc(tlsf_t *t, void *mem, size_t size);
 
 /**
@@ -445,7 +445,7 @@ void *tlsf_realloc(tlsf_t *t, void *mem, size_t size);
 /*@
   requires \valid(t);
   requires mem != \null ==> tlsf_payload_header(mem);
-*/
+ */
 void tlsf_free(tlsf_t *t, void *mem);
 
 /**
@@ -462,7 +462,7 @@ void tlsf_free(tlsf_t *t, void *mem);
 /*@
   requires ptr != \null ==> tlsf_payload_header(ptr);
   ensures ptr == \null ==> \result == 0;
-*/
+ */
 size_t tlsf_usable_size(void *ptr);
 
 /**
@@ -521,7 +521,7 @@ typedef struct {
     ensures \result == 0 || \result == -1;
   complete behaviors;
   disjoint behaviors;
-*/
+ */
 int tlsf_get_stats(tlsf_t *t, tlsf_stats_t *stats);
 
 #ifdef __cplusplus

--- a/include/tlsf.h
+++ b/include/tlsf.h
@@ -146,6 +146,7 @@ extern "C" {
 #define tlsf_pool_init _TLSF_ABI(tlsf_pool_init)
 #define tlsf_pool_reset _TLSF_ABI(tlsf_pool_reset)
 #define tlsf_malloc _TLSF_ABI(tlsf_malloc)
+#define tlsf_calloc _TLSF_ABI(tlsf_calloc)
 #define tlsf_realloc _TLSF_ABI(tlsf_realloc)
 #define tlsf_free _TLSF_ABI(tlsf_free)
 #define tlsf_usable_size _TLSF_ABI(tlsf_usable_size)
@@ -405,6 +406,25 @@ void tlsf_pool_reset(tlsf_t *t);
   ensures \result == \null || \valid(((char *)\result) + (0 .. size - 1));
  */
 void *tlsf_malloc(tlsf_t *t, size_t size);
+
+/**
+ * Allocate zero-initialized memory for an array.
+ *
+ * @t : The TLSF allocator instance
+ * @nmemb : Number of array elements
+ * @size : Size of each element
+ *
+ * Return Pointer to at least @nmemb * @size zeroed bytes, or NULL if the
+ * multiplication overflows or allocation fails. A zero total size returns a
+ * unique minimum-sized allocation, consistent with tlsf_malloc().
+ */
+/*@
+  requires \valid(t);
+  ensures nmemb != 0 && size > SIZE_MAX / nmemb ==> \result == \null;
+  ensures \result == \null ||
+    \valid(((char *)\result) + (0 .. nmemb * size - 1));
+ */
+void *tlsf_calloc(tlsf_t *t, size_t nmemb, size_t size);
 
 /**
  * Resize an existing allocation, preserving its contents up to the smaller of

--- a/src/tlsf.c
+++ b/src/tlsf.c
@@ -1592,6 +1592,18 @@ void *tlsf_malloc(tlsf_t *t, size_t size)
     return block_use(t, block, size);
 }
 
+void *tlsf_calloc(tlsf_t *t, size_t nmemb, size_t size)
+{
+    if (UNLIKELY(nmemb && size > SIZE_MAX / nmemb))
+        return NULL;
+
+    size *= nmemb;
+    void *mem = tlsf_malloc(t, size);
+    if (mem)
+        memset(mem, 0, size);
+    return mem;
+}
+
 /* The bound below subtracts 'align' and the block struct from TLSF_MAX_SIZE,
  * and that subtraction leans on the power-of-two test two lines above it: the
  * largest power of two not exceeding TLSF_MAX_SIZE is under half of it, which

--- a/tests/test.c
+++ b/tests/test.c
@@ -1070,6 +1070,66 @@ static void static_pool_test(void)
     printf(". done\n");
 }
 
+static void calloc_test(void)
+{
+    printf("Calloc test: ");
+    fflush(stdout);
+
+    static unsigned char pool[4096];
+    memset(pool, 0xA5, sizeof(pool));
+
+    tlsf_t t;
+    assert(tlsf_pool_init(&t, pool, sizeof(pool)) > 0);
+
+    tlsf_stats_t before, after;
+    assert(tlsf_get_stats(&t, &before) == 0);
+
+    /* Two wrap targets, each in both operand orders. The 'half' pairs wrap the
+     * product to zero, which tlsf_malloc honors as a minimum-sized request; the
+     * 'wrap' pairs wrap it to 4, which tlsf_malloc would satisfy outright. A
+     * guard that merely rejects a zero product passes the first pair, so the
+     * second pair is what pins the check to the operands rather than the
+     * product.
+     */
+    size_t half = SIZE_MAX / 2 + 1;
+    assert(tlsf_calloc(&t, half, 2) == NULL);
+    assert(tlsf_calloc(&t, 2, half) == NULL);
+
+    size_t wrap = SIZE_MAX / 4 + 2;
+    assert(tlsf_calloc(&t, wrap, 4) == NULL);
+    assert(tlsf_calloc(&t, 4, wrap) == NULL);
+
+    assert(tlsf_get_stats(&t, &after) == 0);
+    assert(after.total_free == before.total_free);
+    assert(after.largest_free == before.largest_free);
+    assert(after.total_used == before.total_used);
+    assert(after.block_count == before.block_count);
+    assert(after.free_count == before.free_count);
+    assert(after.overhead == before.overhead);
+
+    unsigned char *p = (unsigned char *) tlsf_calloc(&t, 17, 3);
+    assert(p);
+    for (size_t i = 0; i < 51; i++)
+        assert(p[i] == 0);
+
+    /* Drive the inner tlsf_malloc() to failure. The product is representable,
+     * so the overflow guard hands it through, and a fixed pool this size cannot
+     * satisfy it. Nothing else in the suite reaches that arm, which must return
+     * NULL rather than zeroing through a null pointer.
+     */
+    assert(tlsf_calloc(&t, 1, sizeof(pool) * 16) == NULL);
+
+    void *zero_a = tlsf_calloc(&t, 0, SIZE_MAX);
+    void *zero_b = tlsf_calloc(&t, SIZE_MAX, 0);
+    assert(zero_a && zero_b && zero_a != zero_b);
+
+    tlsf_free(&t, zero_b);
+    tlsf_free(&t, zero_a);
+    tlsf_free(&t, p);
+    tlsf_check(&t);
+    printf("done\n");
+}
+
 /* Test zero-size and alignment edge cases. Validates consistent behavior
  * between tlsf_malloc and tlsf_aalloc.
  */
@@ -1824,6 +1884,9 @@ int main(void)
 
     /* Run static pool test */
     static_pool_test();
+
+    /* Run zero-initialized allocation test */
+    calloc_test();
 
     /* Run pool reset test */
     pool_reset_test();

--- a/tests/test.c
+++ b/tests/test.c
@@ -1205,6 +1205,15 @@ static void zero_size_align_test(tlsf_t *t)
         assert(tlsf_aalloc(t, 6, 100) == NULL);
         assert(tlsf_aalloc(t, 7, 100) == NULL);
         assert(tlsf_aalloc(t, 9, 100) == NULL);
+
+        /* A power of two that is still too large. TLSF_MAX_SIZE is '1 <<
+         * (_TLSF_FL_MAX - 1)' less one word, so adding the word back gives
+         * exactly that power of two, the smallest one the alignment bound
+         * rejects. Nothing else covers this clause deterministically: the
+         * thread stress test reaches it incidentally, a couple of times in
+         * some forty thousand calls or not at all, depending on scheduling.
+         */
+        assert(tlsf_aalloc(t, TLSF_MAX_SIZE + sizeof(size_t), 100) == NULL);
     }
     printf(".");
     fflush(stdout);


### PR DESCRIPTION
Adds tlsf_calloc, the one allocation entry point the API was missing. Callers building an array otherwise write the nmemb times size multiplication themselves, and an overflow there hands tlsf_malloc a wrapped size that it satisfies with a block far smaller than the caller believes it owns. The guard rejects the overflow before any allocator state moves. A zero total size keeps tlsf_malloc's unique minimum-sized allocation rather than returning NULL, and only the requested byte count is zeroed, not the rounded-up block.

The ACSL contract carries the same validity postcondition tlsf_malloc already states, rather than only the overflow rejection. tlsf_calloc is absent from WP_FUNCTIONS, so that contract is an assumption handed to callers and an incomplete one is worse than none. That its "nmemb * size" reads as the entry values, despite the implementation reusing the size parameter, was settled against Frama-C rather than assumed.

Branch coverage of src/tlsf.c is now gated too. It had been measured and discarded while line coverage was ratcheted at 99 percent, so a change could add an untested branch without moving the number CI watches. The 62 CHECK() arms in tlsf_check() are excluded, unreachable in a passing run exactly as the ASSERT lines the script already compiles out; over the 222 remaining branches the figure is 94.14 percent. The floor is 90 rather than tracking that, because it was calibrated on clang while the coverage job runs gcc, and the two decompose short-circuit operators into different branch counts. Worth reading what CI prints over a few runs and raising it to just under the lowest.

The first commit is a comment-whitespace normalization of include/tlsf.h, unrelated to the rest and kept separate so it can be reverted on its own.

Verified with "make check" in both the default and TLSF_DEBUG_FLAGS= configurations, "make verify" at 380 of 380 goals, and the format, newline, ABI-guard and coverage gates under .ci. Each of the four commits was checked out and built on its own. Deleting the overflow guard aborts the suite on its first assertion, and replacing it with one that rejects only a zero product aborts on the second pair.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `tlsf_calloc` to the allocator API and gates branch coverage of `src/tlsf.c` in CI.

**`tlsf_calloc`**
- New entry point accepts `nmemb` and `size`, rejecting multiplication overflow before any allocator state moves.
- Zero total size returns a unique minimum-sized allocation, consistent with `tlsf_malloc`, and only the requested bytes are zeroed.
- ACSL contract mirrors `tlsf_malloc`'s validity postcondition; the function is not yet in `WP_FUNCTIONS`.
- Tests drive both operand orders through two overflow targets and allocator failure; a guard that only rejects zero product fails them.

**Branch coverage gate**
- CI now enforces a 93% floor on reachable branches; the 62 `CHECK()` arms are excluded as unreachable in a passing run.
- The floor was raised from 90 after CI measured 94.48% on gcc against 94.14% on clang; 93 clears both toolchains with the one-branch run-to-run jitter.
- Test seed is pinned for reproducible coverage runs, though the branch count still varies by one due to scheduling.
- A separate commit adds a deterministic test for the `tlsf_aalloc` alignment ceiling, which previously was only incidentally covered.
- Comment-whitespace normalization of `tlsf.h` is kept separate for independent revert.

<sup>Written for commit 219930d588fed2f9dfcb984a4f45d99f64e726a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/tlsf-bsd/pull/48?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

